### PR TITLE
Fix project setup to be compatible with github-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:integ": "jest -c jest.integ.config.js",
     "test": "npm run test:unit && npm-run-all -r -p test-pages test:integ",
     "lint": "eslint --ignore-path .gitignore --ext ts,tsx,js .",
-    "preinstall": "./scripts/preinstall.js",
+    "preinstall": "node ./scripts/in-github-workflow.js && ./scripts/prepare-package-lock.js || :",
     "prepublishOnly": "rimraf ./dist && npm run build",
     "prepare": "husky install"
   },
@@ -77,7 +77,7 @@
       "eslint --fix"
     ],
     "package-lock.json": [
-      "./scripts/lint-staged.js"
+      "./scripts/prepare-package-lock.js"
     ]
   }
 }

--- a/scripts/in-github-workflow.js
+++ b/scripts/in-github-workflow.js
@@ -3,5 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 if (process.env.GITHUB_WORKFLOW) {
-  require('./prepare-package-lock.js');
+  process.exit(0);
+} else {
+  process.exit(1);
 }

--- a/scripts/lint-staged.js
+++ b/scripts/lint-staged.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-require('./prepare-package-lock.js');


### PR DESCRIPTION
When prepare-package-lock is run on the pre-install step it fails the package import in github-build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
