### PR TITLE
chore: Revert preinstall scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "@cloudscape-design/component-toolkit",
   "version": "1.0.0",
   "files": [
-    "lib",
-    "scripts"
+    "lib/*"
   ],
   "main": "./lib/index.js",
   "exports": {
@@ -23,7 +22,7 @@
     "test:integ": "jest -c jest.integ.config.js",
     "test": "npm run test:unit && npm-run-all -r -p test-pages test:integ",
     "lint": "eslint --ignore-path .gitignore --ext ts,tsx,js .",
-    "preinstall": "./scripts/prepare-package-lock.js",
+    "preinstall": "node ./scripts/in-github-workflow.js && ./scripts/prepare-package-lock.js || :",
     "prepublishOnly": "rimraf ./dist && npm run build",
     "prepare": "husky install"
   },

--- a/scripts/in-github-workflow.js
+++ b/scripts/in-github-workflow.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+if (process.env.GITHUB_WORKFLOW) {
+  process.exit(0);
+} else {
+  process.exit(1);
+}

--- a/scripts/prepare-package-lock.js
+++ b/scripts/prepare-package-lock.js
@@ -2,16 +2,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// only run this within the scope of this package
-if (process.env.npm_package_name && process.env.npm_package_name !== '@cloudscape-design/component-toolkit') {
-  return;
-}
-
 /**
  * Remove specific @cloudscape-design/* packages where we should always use the latest minor release.
  * Also checks for any dependencies that incorrectly use CodeArtifact instead of npm.
  */
+
 const fs = require('fs');
+
 const filename = require.resolve('../package-lock.json');
 const packageLock = require(filename);
 


### PR DESCRIPTION
Partially revert https://github.com/cloudscape-design/component-toolkit/pull/4

The husky changes are useful, but the preinstall hook has to stay


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
