### PR TITLE
fix codeowners declaration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@cloudscape-design/cloudscape-dev
+*       @cloudscape-design/cloudscape-dev


### PR DESCRIPTION
In the current version the file does not do what you expect.

It declares `/@cloudscape-design/cloudscape-dev/` folder as "ownerless"

The expected syntax is `<path>    <team>`

--

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
