### PR TITLE
fix: add `tslib` to `dependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0-beta",
       "hasInstallScript": true,
       "dependencies": {
-        "@juggle/resize-observer": "^3.3.1"
+        "@juggle/resize-observer": "^3.3.1",
+        "tslib": "^2.3.1"
       },
       "devDependencies": {
         "@cloudscape-design/browser-test-tools": "^3.0.0",
@@ -43,7 +44,6 @@
         "ts-jest": "^27.1.3",
         "ts-loader": "^9.2.6",
         "ts-node": "^10.7.0",
-        "tslib": "^2.3.1",
         "typescript": "^4.6.3",
         "vite": "^2.9.5"
       }
@@ -12445,8 +12445,7 @@
     "node_modules/tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -22529,8 +22528,7 @@
     "tslib": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@juggle/resize-observer": "^3.3.1"
+    "@juggle/resize-observer": "^3.3.1",
+    "tslib": "^2.3.1"
   },
   "devDependencies": {
     "@cloudscape-design/browser-test-tools": "^3.0.0",
@@ -66,7 +67,6 @@
     "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.7.0",
-    "tslib": "^2.3.1",
     "typescript": "^4.6.3",
     "vite": "^2.9.5"
   },


### PR DESCRIPTION
`tslib` is included in the final bundled output, therefore it needs to be a peer dependency in addition to a development dependency.

(This change is also applicable to the AWS UI component toolkit, which is not present on GitHub for a PR.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
