### PR TITLE
chore: Align warnOnce format with components/internal/logging

### DIFF
--- a/src/internal/logging.ts
+++ b/src/internal/logging.ts
@@ -1,12 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isDevelopment } from './is-development';
+
 const messageCache: Record<string, true | undefined> = {};
 
 export function warnOnce(component: string, message: string): void {
-  const warning = `[${component}] ${message}`;
-  if (!messageCache[warning]) {
-    messageCache[warning] = true;
-    console.warn(warning);
+  if (isDevelopment) {
+    const warning = `[AwsUi] [${component}] ${message}`;
+    if (!messageCache[warning]) {
+      messageCache[warning] = true;
+      console.warn(warning);
+    }
   }
 }

--- a/src/use-controllable-state/__tests__/use-controllable.test.tsx
+++ b/src/use-controllable-state/__tests__/use-controllable.test.tsx
@@ -61,7 +61,7 @@ describe('useControllableState', () => {
     expect(ref.current!.value).toBe(undefined);
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
-      "[MyComponent] A component tried to change controlled 'value' property to be uncontrolled. " +
+      "[AwsUi] [MyComponent] A component tried to change controlled 'value' property to be uncontrolled. " +
         'This is not supported. Properties should not switch from controlled to uncontrolled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled mode for the lifetime of the component. ' +
         'More info: https://fb.me/react-controlled-components'
@@ -80,7 +80,7 @@ describe('useControllableState', () => {
     expect(ref.current!.value).toBe('the default value');
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
-      "[MyComponent] A component tried to change uncontrolled 'value' property to be controlled. " +
+      "[AwsUi] [MyComponent] A component tried to change uncontrolled 'value' property to be controlled. " +
         'This is not supported. Properties should not switch from uncontrolled to controlled (or vice versa). ' +
         'Decide between using a controlled or uncontrolled mode for the lifetime of the component. ' +
         'More info: https://fb.me/react-controlled-components'
@@ -94,7 +94,7 @@ describe('useControllableState', () => {
 
     expect(console.warn).toHaveBeenCalledTimes(1);
     expect(console.warn).toHaveBeenCalledWith(
-      '[MyComponent] You provided a `value` prop without an `onChange` handler. This will render a non-interactive component.'
+      '[AwsUi] [MyComponent] You provided a `value` prop without an `onChange` handler. This will render a non-interactive component.'
     );
   });
 


### PR DESCRIPTION
The `warnOnce` function requires the same format as in components repository so that the function and dependant functions can be consumed from the toolkit. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
