### PR TITLE
fix: Type of useContainerQuery ref should be ref object

### DIFF
--- a/src/container-queries/use-container-query.ts
+++ b/src/container-queries/use-container-query.ts
@@ -35,7 +35,7 @@ import useResizeObserver from './use-resize-observer';
 export default function useContainerQuery<ObservedState>(
   mapFn: (entry: ContainerQueryEntry, prev: null | ObservedState) => ObservedState,
   deps: React.DependencyList = []
-): [null | ObservedState, React.Ref<any>] {
+): [null | ObservedState, React.RefObject<any>] {
   const elementRef = useRef<HTMLElement>(null);
   const [state, setState] = useState<null | ObservedState>(null);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Ref in the containerQuery is always RefObject
https://github.com/cloudscape-design/component-toolkit/blob/4fb5b49cd44867baa74472eded9e7b4e897e6128/src/container-queries/use-container-query.ts#L39

, but it returns as Ref
https://github.com/cloudscape-design/component-toolkit/blob/a1f138c17d8104e27e56f40410152337483ad73b/src/container-queries/use-container-query.ts#L38


 
It makes problem when using `ref.current ` because typescript thinks it can be ref callbacks. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
