### PR TITLE
refactor: Add original isMotionDisabled tests from components

### DIFF
--- a/src/internal/visual-mode/__tests__/motion.test.tsx
+++ b/src/internal/visual-mode/__tests__/motion.test.tsx
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { isMotionDisabled } from '../index';
+
+const matchMedia = jest.fn();
+window.matchMedia = matchMedia;
+
+beforeEach(() => {
+  matchMedia.mockReturnValue({ matches: false });
+});
+
+describe('isMotionDisabled', () => {
+  test('returns false when there is no awsui-motion-disabled class', () => {
+    const renderResult = render(
+      <div>
+        <div id="test-element">Content</div>
+      </div>
+    );
+    const element = renderResult.container.querySelector('#test-element') as HTMLElement;
+    expect(isMotionDisabled(element)).toEqual(false);
+  });
+  test('returns true when a parent element has awsui-motion-disabled class', () => {
+    const renderResult = render(
+      <div className="awsui-motion-disabled">
+        <div>
+          <div>
+            <div>
+              <div>
+                <div id="test-element">Content</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+    const element = renderResult.container.querySelector('#test-element') as HTMLElement;
+    expect(isMotionDisabled(element)).toEqual(true);
+  });
+  test('returns false when there is an element with class awsui-motion-disabled, but it is not in the hierarchy', () => {
+    const renderResult = render(
+      <div>
+        <div className="awsui-motion-disabled">Content</div>
+        <div id="test-element">Content</div>
+      </div>
+    );
+    const element = renderResult.container.querySelector('#test-element') as HTMLElement;
+    expect(isMotionDisabled(element)).toEqual(false);
+  });
+  test('returns true with prefers-reduced-motion: reduce ', () => {
+    matchMedia.mockReturnValue({ matches: true });
+    const renderResult = render(
+      <div>
+        <div id="test-element">Content</div>
+      </div>
+    );
+    const element = renderResult.container.querySelector('#test-element') as HTMLElement;
+    expect(isMotionDisabled(element)).toEqual(true);
+  });
+  test('returns true with prefers-reduced-motion: reduce and class awsui-motion-disabled', () => {
+    matchMedia.mockReturnValue({ matches: true });
+    const renderResult = render(
+      <div className="awsui-motion-disabled">
+        <div id="test-element">Content</div>
+      </div>
+    );
+    const element = renderResult.container.querySelector('#test-element') as HTMLElement;
+    expect(isMotionDisabled(element)).toEqual(true);
+  });
+});

--- a/src/internal/visual-mode/__tests__/use-visual-mode.test.tsx
+++ b/src/internal/visual-mode/__tests__/use-visual-mode.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { useRef } from 'react';
-import { useCurrentMode, useDensityMode, isMotionDisabled, useReducedMotion } from '../index';
+import { useCurrentMode, useDensityMode, useReducedMotion } from '../index';
 import { render, screen } from '@testing-library/react';
 import { mutate } from './utils';
 
@@ -96,53 +96,6 @@ describe('useDensityMode', () => {
     expect(screen.getByTestId('current-mode')).toHaveTextContent('compact');
     await mutate(() => container.classList.remove('awsui-polaris-compact-mode'));
     expect(screen.getByTestId('current-mode')).toHaveTextContent('comfortable');
-  });
-});
-
-describe('isMotionDisabled', () => {
-  const originalMatchMedia = window.matchMedia;
-  let matchedMediaExpression = '';
-
-  beforeEach(() => {
-    matchedMediaExpression = '';
-    window.matchMedia = (expression: string) => {
-      if (expression === matchedMediaExpression) {
-        return { matches: true } as MediaQueryList;
-      }
-      return { matches: false } as MediaQueryList;
-    };
-  });
-
-  afterEach(() => {
-    window.matchMedia = originalMatchMedia;
-  });
-
-  test('returns true if "awsui-motion-disabled" class is set', () => {
-    render(
-      <div className="awsui-motion-disabled">
-        <div data-testid="target"></div>
-      </div>
-    );
-    expect(isMotionDisabled(screen.getByTestId('target'))).toBe(true);
-  });
-
-  test('returns true if media (prefers-reduced-motion: reduce) is set', () => {
-    matchedMediaExpression = '(prefers-reduced-motion: reduce)';
-    render(
-      <div>
-        <div data-testid="target"></div>
-      </div>
-    );
-    expect(isMotionDisabled(screen.getByTestId('target'))).toBe(true);
-  });
-
-  test('returns false if no class or media set', () => {
-    render(
-      <div>
-        <div data-testid="target"></div>
-      </div>
-    );
-    expect(isMotionDisabled(screen.getByTestId('target'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
When updating components to use visual-mode utils from the toolkit I found out there were tests created for isMotionDisabled. Using this tests instead of ones introduced previously.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
