### PR TITLE
feat: Support `componentConfiguration` in the component metadata property

### DIFF
--- a/src/internal/base-component/__tests__/use-component-metadata.test.tsx
+++ b/src/internal/base-component/__tests__/use-component-metadata.test.tsx
@@ -5,15 +5,31 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { useComponentMetadata, COMPONENT_METADATA_KEY } from '../component-metadata';
 
-function TestComponent() {
-  const ref = useComponentMetadata('test-component', '3.0.0');
-  return <div ref={ref}>Test</div>;
-}
-
 test('should attach readonly metadata to the returned root DOM node', () => {
+  function TestComponent() {
+    const ref = useComponentMetadata('test-component', '3.0.0');
+    return <div ref={ref}>Test</div>;
+  }
+
   const { container } = render(<TestComponent />);
   const rootNode: any = container.firstChild;
 
   expect(rootNode[COMPONENT_METADATA_KEY]).toEqual({ name: 'test-component', version: '3.0.0' });
   expect(Object.isFrozen(rootNode[COMPONENT_METADATA_KEY])).toBe(true);
+});
+
+test('supports optional component configuration information', () => {
+  function TestComponent() {
+    const ref = useComponentMetadata('test-component', '3.0.0', { type: 'success' });
+    return <div ref={ref}>Test</div>;
+  }
+
+  const { container } = render(<TestComponent />);
+  const rootNode: any = container.firstChild;
+
+  expect(rootNode[COMPONENT_METADATA_KEY]).toEqual({
+    name: 'test-component',
+    version: '3.0.0',
+    componentConfiguration: { type: 'success' },
+  });
 });

--- a/src/internal/base-component/component-metadata.ts
+++ b/src/internal/base-component/component-metadata.ts
@@ -13,6 +13,7 @@ export function useComponentMetadata<T = any>(
   interface AwsUiMetadata {
     name: string;
     version: string;
+    componentConfiguration?: Record<string, any>;
   }
 
   interface HTMLMetadataElement extends HTMLElement {
@@ -24,7 +25,7 @@ export function useComponentMetadata<T = any>(
   useEffect(() => {
     if (elementRef.current && !Object.prototype.hasOwnProperty.call(elementRef.current, COMPONENT_METADATA_KEY)) {
       const node = elementRef.current as unknown as HTMLMetadataElement;
-      const metadata = { componentConfiguration, name: componentName, version: packageVersion };
+      const metadata: AwsUiMetadata = { componentConfiguration, name: componentName, version: packageVersion };
 
       Object.freeze(metadata);
       Object.defineProperty(node, COMPONENT_METADATA_KEY, { value: metadata, writable: false });

--- a/src/internal/base-component/component-metadata.ts
+++ b/src/internal/base-component/component-metadata.ts
@@ -5,7 +5,11 @@ import { useEffect, useRef } from 'react';
 
 export const COMPONENT_METADATA_KEY = '__awsuiMetadata__';
 
-export function useComponentMetadata<T = any>(componentName: string, packageVersion: string) {
+export function useComponentMetadata<T = any>(
+  componentName: string,
+  packageVersion: string,
+  componentConfiguration?: Record<string, any>
+) {
   interface AwsUiMetadata {
     name: string;
     version: string;
@@ -20,7 +24,7 @@ export function useComponentMetadata<T = any>(componentName: string, packageVers
   useEffect(() => {
     if (elementRef.current && !Object.prototype.hasOwnProperty.call(elementRef.current, COMPONENT_METADATA_KEY)) {
       const node = elementRef.current as unknown as HTMLMetadataElement;
-      const metadata = { name: componentName, version: packageVersion };
+      const metadata = { componentConfiguration, name: componentName, version: packageVersion };
 
       Object.freeze(metadata);
       Object.defineProperty(node, COMPONENT_METADATA_KEY, { value: metadata, writable: false });


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
This PR extends our `useComponentMetadata` hook with an option to provide additional component-specific metadata. We plan to use this option to expose e.g. whether a button is a primary or default variant, what the placeholder text of a Select is, and so on. See also document FZakAmaNW5fQ .

Example usage in the Button component:
```js
const baseComponentProps = useBaseComponent('Button', { variant, disabled, loading });
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
