### PR TITLE
chore: Add useVisualRefresh hook to internal

### DIFF
--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -8,6 +8,12 @@ export { Metrics } from './base-component/metrics/metrics';
 export { useResizeObserver } from './container-queries/use-resize-observer';
 export { createSingletonHandler, createSingletonState, UseSingleton } from './singleton-handler';
 export { useStableCallback } from './stable-callback';
-export { isMotionDisabled, useCurrentMode, useDensityMode, useReducedMotion } from './visual-mode';
+export {
+  isMotionDisabled,
+  useCurrentMode,
+  useDensityMode,
+  useReducedMotion,
+  useRuntimeVisualRefresh,
+} from './visual-mode';
 export { isDevelopment } from './is-development';
 export { warnOnce } from './logging';

--- a/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
+++ b/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { useRuntimeVisualRefresh, clearVisualRefreshState } from '../index';
+import { render, screen } from '@testing-library/react';
+
+const awsuiVisualRefreshFlag = Symbol.for('awsui-visual-refresh-flag');
+interface ExtendedWindow extends Window {
+  [awsuiVisualRefreshFlag]?: () => boolean;
+}
+declare const window: ExtendedWindow;
+
+describe('useVisualRefresh', () => {
+  function App() {
+    const isRefresh = useRuntimeVisualRefresh();
+    return <div data-testid="current-mode">{isRefresh.toString()}</div>;
+  }
+
+  beforeEach(() => clearVisualRefreshState());
+  afterEach(() => document.body.classList.remove('awsui-visual-refresh'));
+  afterEach(() => jest.restoreAllMocks());
+
+  test('should return false when class name is not present', () => {
+    render(<App />);
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+  });
+
+  test('should return true when class name is present', () => {
+    document.body.classList.add('awsui-visual-refresh');
+    render(<App />);
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+  });
+
+  test('should print a warning when late visual refresh class name was detected', () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { rerender } = render(<App />);
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+    expect(console.warn).not.toHaveBeenCalled();
+
+    document.body.classList.add('awsui-visual-refresh');
+    rerender(<App />);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/Dynamic visual refresh change detected/));
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+  });
+
+  describe('Window Symbol awsui-visual-refresh-flag', () => {
+    afterEach(() => {
+      window[awsuiVisualRefreshFlag] = undefined;
+    });
+
+    test('should return true when Window Symbol awsui-visual-refresh-flag returns true', () => {
+      window[awsuiVisualRefreshFlag] = () => true;
+      render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+    });
+
+    test('should return false when Window Symbol awsui-visual-refresh-flag returns false', () => {
+      window[awsuiVisualRefreshFlag] = () => false;
+      render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+    });
+
+    test('should not change theme when Window Symbol awsui-visual-refresh-flag is set later', () => {
+      const { rerender } = render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+
+      window[awsuiVisualRefreshFlag] = () => true;
+      rerender(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('false');
+    });
+
+    test('should return true when Window Symbol awsui-visual-refresh-flag returns false but class name is present', () => {
+      document.body.classList.add('awsui-visual-refresh');
+      window[awsuiVisualRefreshFlag] = () => false;
+      render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+    });
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Move [`useVisualRefreshDynamic` in Component ](https://github.com/cloudscape-design/components/blob/main/src/internal/hooks/use-visual-mode/index.ts#L17) into toolkit, reduce duplications in Components and [Dashboard](https://github.com/cloudscape-design/components/blob/main/src/internal/hooks/use-visual-mode/index.ts#L17)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
