### PR TITLE
fix: check for descendant nodeType in nodeContains function

### DIFF
--- a/src/dom/node-contains.ts
+++ b/src/dom/node-contains.ts
@@ -7,7 +7,10 @@
  * @param descendant Node that is checked to be a descendant of the parent node
  */
 export default function nodeContains(parent: Node | null, descendant: Node | EventTarget | null) {
-  if (!parent || !descendant || !(descendant instanceof Node)) {
+  // ('nodeType' in descendant) is a workaround to check if descendant is a node
+  //  Node interface is tied to the window it's created in, if the descendant was moved to an iframe after it was created,
+  //  descendant instanceof Node will be false since Node has a different window
+  if (!parent || !descendant || !('nodeType' in descendant)) {
     return false;
   }
 


### PR DESCRIPTION
this might crazy but we have a very rare edge case when the parent and descendant elements are created in a window instance and then rendered in an iframe making `descendant instanceof Node` false since `descendant` has a different `window.Node` 

This PR uses `nodeType` instead
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
