### PR TITLE
remove extended component metadata reporting

### DIFF
--- a/src/internal/base-component/__tests__/use-component-metadata.test.tsx
+++ b/src/internal/base-component/__tests__/use-component-metadata.test.tsx
@@ -17,19 +17,3 @@ test('should attach readonly metadata to the returned root DOM node', () => {
   expect(rootNode[COMPONENT_METADATA_KEY]).toEqual({ name: 'test-component', version: '3.0.0' });
   expect(Object.isFrozen(rootNode[COMPONENT_METADATA_KEY])).toBe(true);
 });
-
-test('supports optional component configuration information', () => {
-  function TestComponent() {
-    const ref = useComponentMetadata('test-component', '3.0.0', { type: 'success' });
-    return <div ref={ref}>Test</div>;
-  }
-
-  const { container } = render(<TestComponent />);
-  const rootNode: any = container.firstChild;
-
-  expect(rootNode[COMPONENT_METADATA_KEY]).toEqual({
-    name: 'test-component',
-    version: '3.0.0',
-    componentConfiguration: { type: 'success' },
-  });
-});

--- a/src/internal/base-component/component-metadata.ts
+++ b/src/internal/base-component/component-metadata.ts
@@ -5,27 +5,22 @@ import { useEffect, useRef } from 'react';
 
 export const COMPONENT_METADATA_KEY = '__awsuiMetadata__';
 
-export function useComponentMetadata<T = any>(
-  componentName: string,
-  packageVersion: string,
-  componentConfiguration?: Record<string, any>
-) {
-  interface AwsUiMetadata {
-    name: string;
-    version: string;
-    componentConfiguration?: Record<string, any>;
-  }
+interface AwsUiMetadata {
+  name: string;
+  version: string;
+}
 
-  interface HTMLMetadataElement extends HTMLElement {
-    [COMPONENT_METADATA_KEY]: AwsUiMetadata;
-  }
+interface HTMLMetadataElement extends HTMLElement {
+  [COMPONENT_METADATA_KEY]: AwsUiMetadata;
+}
 
+export function useComponentMetadata<T = any>(componentName: string, packageVersion: string) {
   const elementRef = useRef<T>(null);
 
   useEffect(() => {
     if (elementRef.current) {
       const node = elementRef.current as unknown as HTMLMetadataElement;
-      const metadata: AwsUiMetadata = { componentConfiguration, name: componentName, version: packageVersion };
+      const metadata: AwsUiMetadata = { name: componentName, version: packageVersion };
 
       Object.freeze(metadata);
       Object.defineProperty(node, COMPONENT_METADATA_KEY, { value: metadata, writable: false, configurable: true });


### PR DESCRIPTION
*Description of changes:*

This is a private API and it is unused after https://github.com/cloudscape-design/components/pull/1928


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
