### PR TITLE
chore: improve component props reporting

### DIFF
--- a/src/internal/base-component/__tests__/metrics.test.ts
+++ b/src/internal/base-component/__tests__/metrics.test.ts
@@ -331,6 +331,21 @@ describe('Client Metrics support', () => {
         c: { props: { variant: 'primary' } },
       });
     });
+
+    test('reports numbers and non-finite numbers', () => {
+      metrics.logComponentUsed('DummyComponentName', {
+        props: { count: 123, notANumber: NaN, maxSize: Number.POSITIVE_INFINITY },
+      });
+      checkMetric(`awsui_DummyComponentName_d10`, {
+        o: 'main',
+        s: 'DummyComponentName',
+        t: 'default',
+        a: 'used',
+        f: 'react',
+        v: '1.0',
+        c: { props: { count: 123, notANumber: 'NaN', maxSize: 'Infinity' } },
+      });
+    });
   });
 
   describe('logComponentsLoaded', () => {

--- a/src/internal/base-component/component-metrics.ts
+++ b/src/internal/base-component/component-metrics.ts
@@ -5,6 +5,8 @@ import { useEffect } from 'react';
 import { Metrics } from './metrics/metrics';
 import { ComponentConfiguration, PackageSettings } from './metrics/interfaces';
 
+export { ComponentConfiguration };
+
 export function useComponentMetrics(
   componentName: string,
   { packageSource, packageVersion, theme }: PackageSettings,

--- a/src/internal/base-component/metrics/formatters.ts
+++ b/src/internal/base-component/metrics/formatters.ts
@@ -19,7 +19,19 @@ export function buildMetricDetail({ source, action, version, configuration }: Me
     v: formatMajorVersionForMetricDetail(version),
     c: configuration as MetricDetail['c'],
   };
-  return JSON.stringify(detailObject);
+  return jsonStringify(detailObject);
+}
+
+export function jsonStringify(detailObject: any) {
+  return JSON.stringify(detailObject, detailSerializer);
+}
+
+function detailSerializer(key: string, value: unknown) {
+  // Report NaN and Infinity as strings instead of `null` (default behavior)
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    return `${value}`;
+  }
+  return value;
 }
 
 export function buildMetricName({ source, version }: MetricsLogItem, theme: string): string {

--- a/src/internal/base-component/metrics/metrics.ts
+++ b/src/internal/base-component/metrics/metrics.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CLogClient, PanoramaClient, MetricsV2EventItem } from './log-clients';
-import { buildMetricDetail, buildMetricName } from './formatters';
+import { buildMetricDetail, buildMetricName, jsonStringify } from './formatters';
 import { ComponentConfiguration, MetricsLogItem } from './interfaces';
 
 const oneTimeMetrics = new Set<string>();
@@ -56,7 +56,7 @@ export class Metrics {
   }
 
   sendMetricObjectOnce(metric: MetricsLogItem, value: number): void {
-    const metricKey = JSON.stringify(metric);
+    const metricKey = jsonStringify(metric);
     if (!oneTimeMetrics.has(metricKey)) {
       this.sendMetricObject(metric, value);
       oneTimeMetrics.add(metricKey);

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { useComponentMetadata, COMPONENT_METADATA_KEY } from './base-component/component-metadata';
-export { useComponentMetrics } from './base-component/component-metrics';
+export { useComponentMetrics, ComponentConfiguration } from './base-component/component-metrics';
 export { initAwsUiVersions } from './base-component/init-awsui-versions';
 export { Metrics } from './base-component/metrics/metrics';
 export { useResizeObserver } from './container-queries/use-resize-observer';


### PR DESCRIPTION
*Description of changes:*

Additional improvements based on the integration experience

1. Re-export `ComponentConfiguration` interface to be used for type declaration here: https://github.com/cloudscape-design/components/blob/0ae969d82aeacfdc297c4a16320eac05b7d1471f/src/internal/hooks/use-base-component/index.ts#L18 
2. Add support for infinite numbers (because `<AppLayout maxContentWidth={Number.POSITIVE_INFINITY}>` is a real use-case)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
