### PR TITLE
feat: Support custom timestamps in metrics

### DIFF
--- a/src/internal/base-component/__tests__/panorama-metrics.test.ts
+++ b/src/internal/base-component/__tests__/panorama-metrics.test.ts
@@ -71,4 +71,9 @@ describe('PanoramaClient', () => {
     expect(window.panorama).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(`Event context for metric is too long: ${eventContext}`);
   });
+
+  test('forwards custom timestamps', () => {
+    panorama.sendMetric({ timestamp: 15 });
+    expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', expect.objectContaining({ timestamp: 15 }));
+  });
 });

--- a/src/internal/base-component/metrics/log-clients.ts
+++ b/src/internal/base-component/metrics/log-clients.ts
@@ -15,6 +15,7 @@ export interface MetricsV2EventItem {
   eventContext?: string;
   eventDetail?: string | Record<string, string | number | boolean>;
   eventValue?: string | Record<string, string | number | boolean>;
+  timestamp?: number;
 }
 
 function validateLength(value: string | undefined, maxLength: number): boolean {
@@ -98,7 +99,7 @@ export class PanoramaClient {
     }
     const panorama = this.findPanorama(window);
     if (typeof panorama === 'function') {
-      panorama('trackCustomEvent', { ...metric, timestamp: Date.now() });
+      panorama('trackCustomEvent', { timestamp: Date.now(), ...metric });
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This change allows to provide a timestamp for a metric event.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
