### PR TITLE
chore: Add analytics metadata property to component nodes

### DIFF
--- a/src/internal/base-component/__tests__/use-component-metadata.test.tsx
+++ b/src/internal/base-component/__tests__/use-component-metadata.test.tsx
@@ -17,3 +17,20 @@ test('should attach readonly metadata to the returned root DOM node', () => {
   expect(rootNode[COMPONENT_METADATA_KEY]).toEqual({ name: 'test-component', version: '3.0.0' });
   expect(Object.isFrozen(rootNode[COMPONENT_METADATA_KEY])).toBe(true);
 });
+
+test('should include analytics property when provided', () => {
+  function TestComponent() {
+    const ref = useComponentMetadata('test-component', '3.0.0', { instanceId: '123' });
+    return <div ref={ref}>Test</div>;
+  }
+
+  const { container } = render(<TestComponent />);
+  const rootNode: any = container.firstChild;
+
+  expect(rootNode[COMPONENT_METADATA_KEY]).toEqual({
+    name: 'test-component',
+    version: '3.0.0',
+    analytics: { instanceId: '123' },
+  });
+  expect(Object.isFrozen(rootNode[COMPONENT_METADATA_KEY])).toBe(true);
+});

--- a/src/internal/base-component/component-metadata.ts
+++ b/src/internal/base-component/component-metadata.ts
@@ -2,25 +2,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useRef } from 'react';
+import { type AnalyticsMetadata } from './metrics/interfaces';
 
 export const COMPONENT_METADATA_KEY = '__awsuiMetadata__';
 
 interface AwsUiMetadata {
   name: string;
   version: string;
+  analytics?: AnalyticsMetadata;
 }
 
 interface HTMLMetadataElement extends HTMLElement {
   [COMPONENT_METADATA_KEY]: AwsUiMetadata;
 }
 
-export function useComponentMetadata<T = any>(componentName: string, packageVersion: string) {
+export function useComponentMetadata<T = any>(
+  componentName: string,
+  packageVersion: string,
+  analyticsMetadata?: AnalyticsMetadata
+) {
   const elementRef = useRef<T>(null);
 
   useEffect(() => {
     if (elementRef.current) {
       const node = elementRef.current as unknown as HTMLMetadataElement;
-      const metadata: AwsUiMetadata = { name: componentName, version: packageVersion };
+      const metadata: AwsUiMetadata = {
+        name: componentName,
+        version: packageVersion,
+      };
+
+      // Only add analytics property to metadata if analytics property is non-empty
+      if (analyticsMetadata && Object.keys(analyticsMetadata).length > 0) {
+        metadata.analytics = analyticsMetadata;
+      }
 
       Object.freeze(metadata);
       Object.defineProperty(node, COMPONENT_METADATA_KEY, { value: metadata, writable: false, configurable: true });

--- a/src/internal/base-component/metrics/interfaces.ts
+++ b/src/internal/base-component/metrics/interfaces.ts
@@ -17,6 +17,8 @@ export interface ComponentConfiguration {
   props: Record<string, JSONValue>;
 }
 
+export type AnalyticsMetadata = Record<string, JSONValue>;
+
 export interface MetricsLogItem {
   source: string;
   // Currently logged actions


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Extends the useComponentMetadata hook to accept an optional field for analytics metadata. This metadata will get stored on the node alongside the component metadata.

Design doc: DM

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
