### PR TITLE
chore: Replace type-only import with full import

### DIFF
--- a/src/internal/base-component/component-metadata.ts
+++ b/src/internal/base-component/component-metadata.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useRef } from 'react';
-import { type AnalyticsMetadata } from './metrics/interfaces';
+import { AnalyticsMetadata } from './metrics/interfaces';
 
 export const COMPONENT_METADATA_KEY = '__awsuiMetadata__';
 


### PR DESCRIPTION
*Issue #, if available:*
n/a


*Description of changes:*

Type-only imports are only supported in Typescript 3.8 or higher. The type-only import prevents consumers of the package to use it in an environment that is using an older Typescript version.

This replaces the type-only import with a full import. Since the imported file has only types, this should not make any difference in the generated Javascript output.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
