### PR TITLE
chore: Replace type-only export with full export

### DIFF
--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -26,4 +26,4 @@ export {
   getLogicalPageX,
 } from './direction';
 export { useFocusVisible } from './focus-visible';
-export { type KeyCode, isModifierKey } from './keycode';
+export { KeyCode, isModifierKey } from './keycode';


### PR DESCRIPTION
Type-only exports are only supported in Typescript 3.8 or higher. The type-only export prevents consumers of the package to use it in an environment that is using an older Typescript version.

This replaces the type-only export with a full export. This should not make any difference in the generated JS output of the internal folder's index file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
