### PR TITLE
chore: Include focus-visible styles in build output

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "scripts": {
     "prebuild": "rm -rf lib",
     "build": "tsc",
-    "postbuild": "cp package.json README.md LICENSE lib",
+    "postbuild": "npm run postbuild:root && npm run postbuild:focus-visible",
+    "postbuild:root": "cp package.json README.md LICENSE lib",
+    "postbuild:focus-visible": "cp ./src/internal/focus-visible/index.scss lib/internal/focus-visible",
     "test-pages": "vite --config ./test-pages/vite.config.mts",
     "test:unit": "jest -c jest.unit.config.js",
     "test:integ": "jest -c jest.integ.config.js",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ensure that styles as well as JS are included in build output for focus-visible.

TBC: if we end up with many more similar helpers that include CSS in the future then we might want to do this in a more automated way, but for now it seems a relatively rare occurrence.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
