### PR TITLE
feat: Utilities for generated analytics metadata

### DIFF
--- a/src/internal/analytics-metadata/__tests__/attributes.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/attributes.test.tsx
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  getAnalyticslabelAttribute,
+  copyAnalyticsMetadataAttribute,
+  getAnalyticsMetadataAttribute,
+  METADATA_DATA_ATTRIBUTE,
+  LABEL_DATA_ATTRIBUTE,
+} from '../attributes';
+
+test('getAnalyticsMetadataAttribute should add data-awsui-analytics attribute', () => {
+  const metadata = { component: { name: 'whatever' } };
+  const { container } = render(<div {...getAnalyticsMetadataAttribute(metadata)} />);
+  expect((container.firstElementChild as HTMLElement).dataset[METADATA_DATA_ATTRIBUTE]).toEqual(
+    JSON.stringify(metadata)
+  );
+});
+
+test('copyAnalyticsMetadataAttribute should select only data-awsui-analytics attribute from a list of props', () => {
+  const metadata = { component: { name: 'whatever' } };
+  const props = { ...getAnalyticsMetadataAttribute(metadata), className: 'test-class' };
+  const { container } = render(<div {...copyAnalyticsMetadataAttribute(props)} />);
+  expect((container.firstElementChild as HTMLElement).dataset[METADATA_DATA_ATTRIBUTE]).toEqual(
+    JSON.stringify(metadata)
+  );
+  expect((container.firstElementChild as HTMLElement).classList.contains('test-class')).toBe(false);
+});
+
+test('getAnalyticslabelAttribute should add data-awsui-analytics-label attribute', () => {
+  const labelIdentifier = 'label-id';
+  const { container } = render(<div {...getAnalyticslabelAttribute(labelIdentifier)} />);
+  expect((container.firstElementChild as HTMLElement).dataset[LABEL_DATA_ATTRIBUTE]).toEqual(labelIdentifier);
+});

--- a/src/internal/analytics-metadata/__tests__/attributes.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/attributes.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import {
-  getAnalyticslabelAttribute,
+  getAnalyticsLabelAttribute,
   copyAnalyticsMetadataAttribute,
   getAnalyticsMetadataAttribute,
   METADATA_DATA_ATTRIBUTE,
@@ -29,8 +29,8 @@ test('copyAnalyticsMetadataAttribute should select only data-awsui-analytics att
   expect((container.firstElementChild as HTMLElement).classList.contains('test-class')).toBe(false);
 });
 
-test('getAnalyticslabelAttribute should add data-awsui-analytics-label attribute', () => {
+test('getAnalyticsLabelAttribute should add data-awsui-analytics-label attribute', () => {
   const labelIdentifier = 'label-id';
-  const { container } = render(<div {...getAnalyticslabelAttribute(labelIdentifier)} />);
+  const { container } = render(<div {...getAnalyticsLabelAttribute(labelIdentifier)} />);
   expect((container.firstElementChild as HTMLElement).dataset[LABEL_DATA_ATTRIBUTE]).toEqual(labelIdentifier);
 });

--- a/src/internal/analytics-metadata/__tests__/components.tsx
+++ b/src/internal/analytics-metadata/__tests__/components.tsx
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { METADATA_ATTRIBUTE, getAnalyticsMetadataAttribute, getAnalyticsLabelAttribute } from '../attributes';
+
+export const ComponentOne = ({ malformed }: { malformed?: boolean }) => (
+  <div
+    {...getAnalyticsMetadataAttribute({
+      component: { name: 'ComponentOne', label: '.component-label', properties: { multi: 'true' } },
+    })}
+  >
+    <div
+      {...(malformed
+        ? { [METADATA_ATTRIBUTE]: "{'corruptedJSON':}" }
+        : getAnalyticsMetadataAttribute({ detail: { keyOne: 'valueOne', keyTwo: 'overriddenValueTwo' } }))}
+    >
+      <div
+        id="target"
+        {...getAnalyticsMetadataAttribute({
+          action: 'select',
+          detail: {
+            label: { selector: ['.event-label', '.second-event-label'], root: 'component' },
+            keyTwo: 'valueTwo',
+          },
+        })}
+      >
+        content
+      </div>
+    </div>
+    <div className="component-label">component label</div>
+    <div className="event-label">event label</div>
+  </div>
+);
+
+const ComponentTwo = () => (
+  <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentTwo', label: '.component-label' } })}>
+    <div className="component-label" {...getAnalyticsLabelAttribute('.sub-label')}>
+      <div className="sub-label">sub label</div>
+      <div>another text content to ignore</div>
+    </div>
+    <div id="id:nested:portal" />
+  </div>
+);
+
+export const ComponentThree = () => (
+  <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentThree' } })}>
+    <div
+      {...getAnalyticsMetadataAttribute({
+        component: { innerContext: { position: '2', columnLabel: { selector: '.invalid-selector', root: 'self' } } },
+      })}
+    >
+      <ComponentTwo />
+      <div data-awsui-referrer-id="id:nested:portal">
+        <ComponentOne />
+      </div>
+    </div>
+  </div>
+);

--- a/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
@@ -4,9 +4,9 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { getAnalyticsMetadataAttribute, METADATA_ATTRIBUTE } from '../attributes';
-import { findNextNode, isNodeComponent, findComponentUp } from '../dom-utils';
+import { findLogicalParent, isNodeComponent, findComponentUp } from '../dom-utils';
 
-describe('findNextNode', () => {
+describe('findLogicalParent', () => {
   test('finds parent', () => {
     const { container } = render(
       <div id="parent">
@@ -14,7 +14,7 @@ describe('findNextNode', () => {
       </div>
     );
     const child = container.querySelector('#child');
-    expect(findNextNode(child as HTMLElement)?.id).toEqual('parent');
+    expect(findLogicalParent(child as HTMLElement)?.id).toEqual('parent');
   });
   test('returns null when child does not exist', () => {
     const { container } = render(
@@ -23,7 +23,7 @@ describe('findNextNode', () => {
       </div>
     );
     const child = container.querySelector('#wrong-child');
-    expect(findNextNode(child as HTMLElement)).toBeNull();
+    expect(findLogicalParent(child as HTMLElement)).toBeNull();
   });
   test('returns null when parent does not exist', () => {
     const { container } = render(
@@ -31,7 +31,7 @@ describe('findNextNode', () => {
         <div id="child"></div>
       </div>
     );
-    expect(findNextNode(container.parentElement?.parentElement as HTMLElement)).toBeNull();
+    expect(findLogicalParent(container.parentElement?.parentElement as HTMLElement)).toBeNull();
   });
   test('returns element referred to with referrerId', () => {
     const { container } = render(
@@ -41,7 +41,7 @@ describe('findNextNode', () => {
       </div>
     );
     const child = container.querySelector('#child');
-    expect(findNextNode(child as HTMLElement)?.classList.contains('parent')).toBe(true);
+    expect(findLogicalParent(child as HTMLElement)?.classList.contains('parent')).toBe(true);
   });
   test('returns null when element referred to with referrerId does not exist', () => {
     const { container } = render(
@@ -51,7 +51,7 @@ describe('findNextNode', () => {
       </div>
     );
     const child = container.querySelector('#child');
-    expect(findNextNode(child as HTMLElement)).toBeNull();
+    expect(findLogicalParent(child as HTMLElement)).toBeNull();
   });
 });
 
@@ -100,7 +100,11 @@ describe('findComponentUp', () => {
     expect(findComponentUp(container.querySelector('#target-element'))?.id).toBe('component-element');
   });
   test('returns null when element has no parent component', () => {
-    const { container } = render(<div />);
-    expect(findComponentUp(container)).toBeNull();
+    const { container } = render(
+      <div>
+        <div id="target-element"></div>
+      </div>
+    );
+    expect(findComponentUp(container.querySelector('#target-element'))).toBeNull();
   });
 });

--- a/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getAnalyticsMetadataAttribute, METADATA_ATTRIBUTE } from '../attributes';
+import { findNextNode, isNodeComponent, findComponentUp } from '../dom-utils';
+
+describe('findNextNode', () => {
+  test('finds parent', () => {
+    const { container } = render(
+      <div id="parent">
+        <div id="child"></div>
+      </div>
+    );
+    const child = container.querySelector('#child');
+    expect(findNextNode(child as HTMLElement)?.id).toEqual('parent');
+  });
+  test('returns null when child does not exist', () => {
+    const { container } = render(
+      <div id="parent">
+        <div id="child"></div>
+      </div>
+    );
+    const child = container.querySelector('#wrong-child');
+    expect(findNextNode(child as HTMLElement)).toBeNull();
+  });
+  test('returns null when parent does not exist', () => {
+    const { container } = render(
+      <div id="parent">
+        <div id="child"></div>
+      </div>
+    );
+    expect(findNextNode(container.parentElement?.parentElement as HTMLElement)).toBeNull();
+  });
+  test('returns element referred to with referrerId', () => {
+    const { container } = render(
+      <div>
+        <div id="child" data-awsui-referrer-id="id:rr5:"></div>
+        <div id="id:rr5:" className="parent"></div>
+      </div>
+    );
+    const child = container.querySelector('#child');
+    expect(findNextNode(child as HTMLElement)?.classList.contains('parent')).toBe(true);
+  });
+  test('returns null when element referred to with referrerId does not exist', () => {
+    const { container } = render(
+      <div>
+        <div id="child" data-awsui-referrer-id="id:rr5:"></div>
+        <div id="id:rr5:wrong" className="parent"></div>
+      </div>
+    );
+    const child = container.querySelector('#child');
+    expect(findNextNode(child as HTMLElement)).toBeNull();
+  });
+});
+
+describe('isNodeComponent', () => {
+  test('returns false when element has no component metadata', () => {
+    const { container } = render(<div />);
+    expect(isNodeComponent(container.firstElementChild as HTMLElement)).toBe(false);
+  });
+  test('returns true when element has component metadata with component name', () => {
+    const { container } = render(<div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })} />);
+    expect(isNodeComponent(container.firstElementChild as HTMLElement)).toBe(true);
+  });
+  test('returns false when element has component metadata without component name', () => {
+    const { container } = render(<div {...getAnalyticsMetadataAttribute({ component: { label: 'labelSelector' } })} />);
+    expect(isNodeComponent(container.firstElementChild as HTMLElement)).toBe(false);
+  });
+  test('returns false when element has corrupted metadata', () => {
+    const { container } = render(<div {...{ [METADATA_ATTRIBUTE]: "{'corruptedJSON':}" }} />);
+    expect(isNodeComponent(container.firstElementChild as HTMLElement)).toBe(false);
+  });
+});
+
+describe('findComponentUp', () => {
+  test('returns null when input is null', () => {
+    expect(findComponentUp(null)).toBeNull();
+  });
+  test('returns parent component element', () => {
+    const { container } = render(
+      <div id="component-element" {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })}>
+        <div id="target-element"></div>
+      </div>
+    );
+    expect(findComponentUp(container.querySelector('#target-element'))?.id).toBe('component-element');
+  });
+  test('returns parent component element with portals', () => {
+    const { container } = render(
+      <div>
+        <div id="component-element" {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })}>
+          <div id=":rr5:"></div>
+        </div>
+        <div data-awsui-referrer-id=":rr5:">
+          <div id="target-element"></div>
+        </div>
+      </div>
+    );
+    expect(findComponentUp(container.querySelector('#target-element'))?.id).toBe('component-element');
+  });
+  test('returns null when element has no parent component', () => {
+    const { container } = render(<div />);
+    expect(findComponentUp(container)).toBeNull();
+  });
+});

--- a/src/internal/analytics-metadata/__tests__/index.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/index.test.tsx
@@ -1,0 +1,118 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getGeneratedAnalyticsMetadata } from '../';
+import { METADATA_ATTRIBUTE, getAnalyticsMetadataAttribute, getAnalyticslabelAttribute } from '../attributes';
+
+const ComponentOne = ({ malformed }: { malformed?: boolean }) => (
+  <div
+    {...getAnalyticsMetadataAttribute({
+      component: { name: 'ComponentOne', label: '.component-label', properties: { multi: 'true' } },
+    })}
+  >
+    <div
+      {...(malformed
+        ? { [METADATA_ATTRIBUTE]: "{'corruptedJSON':}" }
+        : getAnalyticsMetadataAttribute({ detail: { keyOne: 'valueOne', keyTwo: 'overriddenValueTwo' } }))}
+    >
+      <div
+        id="target"
+        {...getAnalyticsMetadataAttribute({
+          action: 'select',
+          detail: { label: { selector: '.event-label', root: 'component' }, keyTwo: 'valueTwo' },
+        })}
+      >
+        content
+      </div>
+    </div>
+    <div className="component-label">component label</div>
+    <div className="event-label">event label</div>
+  </div>
+);
+
+const ComponentTwo = () => (
+  <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentTwo', label: '.component-label' } })}>
+    <div className="component-label" {...getAnalyticslabelAttribute('.sub-label')}>
+      <div className="sub-label">sub label</div>
+      <div>another text content to ignore</div>
+    </div>
+    <div id="id:nested:portal" />
+  </div>
+);
+
+const ComponentThree = () => (
+  <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentThree' } })}>
+    <div
+      {...getAnalyticsMetadataAttribute({
+        component: { innerContext: { position: '2', columnLabel: '.invalid-selector' } },
+      })}
+    >
+      <ComponentTwo />
+      <div data-awsui-referrer-id="id:nested:portal">
+        <ComponentOne />
+      </div>
+    </div>
+  </div>
+);
+
+describe('getGeneratedAnalyticsMetadata', () => {
+  test('returns an empty object when input is null', () => {
+    expect(getGeneratedAnalyticsMetadata(null)).toEqual({});
+  });
+  test('skips malformed metadata', () => {
+    const { container } = render(
+      <div {...{ [METADATA_ATTRIBUTE]: "{'corruptedJSON':}" }}>
+        <ComponentOne malformed={true} />
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(getGeneratedAnalyticsMetadata(target)).toEqual({
+      action: 'select',
+      detail: { label: 'event label', keyTwo: 'valueTwo' },
+      contexts: [
+        {
+          type: 'component',
+          detail: { name: 'ComponentOne', label: 'component label', properties: { multi: 'true' } },
+        },
+      ],
+    });
+  });
+  test('resolves labels and merges metadata', () => {
+    const { container } = render(<ComponentOne />);
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(getGeneratedAnalyticsMetadata(target)).toEqual({
+      action: 'select',
+      detail: { label: 'event label', keyOne: 'valueOne', keyTwo: 'overriddenValueTwo' },
+      contexts: [
+        {
+          type: 'component',
+          detail: { name: 'ComponentOne', label: 'component label', properties: { multi: 'true' } },
+        },
+      ],
+    });
+  });
+  test('resolves contexts chain and label attribute, and redirects portals', () => {
+    const { container } = render(<ComponentThree />);
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(getGeneratedAnalyticsMetadata(target)).toEqual({
+      action: 'select',
+      detail: { label: 'event label', keyOne: 'valueOne', keyTwo: 'overriddenValueTwo' },
+      contexts: [
+        {
+          type: 'component',
+          detail: { name: 'ComponentOne', label: 'component label', properties: { multi: 'true' } },
+        },
+        {
+          type: 'component',
+          detail: { name: 'ComponentTwo', label: 'sub label' },
+        },
+        {
+          type: 'component',
+          detail: { name: 'ComponentThree', innerContext: { position: '2', columnLabel: '' } },
+        },
+      ],
+    });
+  });
+});

--- a/src/internal/analytics-metadata/__tests__/index.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/index.test.tsx
@@ -4,58 +4,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { getGeneratedAnalyticsMetadata } from '../';
-import { METADATA_ATTRIBUTE, getAnalyticsMetadataAttribute, getAnalyticslabelAttribute } from '../attributes';
-
-const ComponentOne = ({ malformed }: { malformed?: boolean }) => (
-  <div
-    {...getAnalyticsMetadataAttribute({
-      component: { name: 'ComponentOne', label: '.component-label', properties: { multi: 'true' } },
-    })}
-  >
-    <div
-      {...(malformed
-        ? { [METADATA_ATTRIBUTE]: "{'corruptedJSON':}" }
-        : getAnalyticsMetadataAttribute({ detail: { keyOne: 'valueOne', keyTwo: 'overriddenValueTwo' } }))}
-    >
-      <div
-        id="target"
-        {...getAnalyticsMetadataAttribute({
-          action: 'select',
-          detail: { label: { selector: '.event-label', root: 'component' }, keyTwo: 'valueTwo' },
-        })}
-      >
-        content
-      </div>
-    </div>
-    <div className="component-label">component label</div>
-    <div className="event-label">event label</div>
-  </div>
-);
-
-const ComponentTwo = () => (
-  <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentTwo', label: '.component-label' } })}>
-    <div className="component-label" {...getAnalyticslabelAttribute('.sub-label')}>
-      <div className="sub-label">sub label</div>
-      <div>another text content to ignore</div>
-    </div>
-    <div id="id:nested:portal" />
-  </div>
-);
-
-const ComponentThree = () => (
-  <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentThree' } })}>
-    <div
-      {...getAnalyticsMetadataAttribute({
-        component: { innerContext: { position: '2', columnLabel: '.invalid-selector' } },
-      })}
-    >
-      <ComponentTwo />
-      <div data-awsui-referrer-id="id:nested:portal">
-        <ComponentOne />
-      </div>
-    </div>
-  </div>
-);
+import { METADATA_ATTRIBUTE } from '../attributes';
+import { ComponentOne, ComponentThree } from './components';
 
 describe('getGeneratedAnalyticsMetadata', () => {
   test('returns an empty object when input is null', () => {

--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { getLabelFromElement, processLabel } from '../labels-utils';
-import { getAnalyticsMetadataAttribute, getAnalyticslabelAttribute } from '../attributes';
+import { getAnalyticsMetadataAttribute, getAnalyticsLabelAttribute } from '../attributes';
 
 describe('getLabelFromElement', () => {
   test('returns an empty string if the element is null', () => {
@@ -125,7 +125,7 @@ describe('processLabel', () => {
     expect(processLabel(target, '')).toEqual('content');
     expect(processLabel(target, { selector: '' })).toEqual('content');
   });
-  test('returns node label when selector is an empty string', () => {
+  test('returns node label when selector is a chain', () => {
     const { container } = render(
       <div>
         <div id="target">
@@ -142,7 +142,7 @@ describe('processLabel', () => {
     expect(processLabel(target, '.label-class h1')).toEqual('label to return');
     expect(processLabel(target, { selector: '.label-class h1' })).toEqual('label to return');
   });
-  test('returns first available label when selector is an array', () => {
+  test('returns first non-empty label when selector is an array', () => {
     const { container } = render(
       <div>
         <div id="target">
@@ -176,8 +176,9 @@ describe('processLabel', () => {
       </div>
     );
     const target = container.querySelector('#target') as HTMLElement;
-
+    //  root="self" refers to the element containing the data attribute
     expect(processLabel(target, { selector: '.label-class', root: 'self' })).toEqual('inner label');
+    //  root="self" refers to the parent component
     expect(processLabel(target, { selector: '.label-class', root: 'component' })).toEqual('outer label');
   });
 
@@ -186,29 +187,29 @@ describe('processLabel', () => {
       <div>
         <div {...getAnalyticsMetadataAttribute({ component: { name: 'FirstComponentName' } })}>
           <div id="target1">
-            <div className="redirect-label-class-one" {...getAnalyticslabelAttribute('#target2 .label-class')}>
+            <div className="redirect-label-class-one" {...getAnalyticsLabelAttribute('#target2 .label-class')}>
               <div id="target2">
                 <div className="label-class">second inner label</div>
               </div>
             </div>
-            <div className="redirect-label-class-two" {...getAnalyticslabelAttribute('h1')}>
+            <div className="redirect-label-class-two" {...getAnalyticsLabelAttribute('h1')}>
               <h1>heading1</h1>
               <h2>heading2</h2>
             </div>
-            <div className="redirect-label-class-three" {...getAnalyticslabelAttribute('')}>
+            <div className="redirect-label-class-three" {...getAnalyticsLabelAttribute('')}>
               <h1>heading1</h1>
               <h2>heading2</h2>
             </div>
-            <div className="redirect-label-class-four" {...getAnalyticslabelAttribute('h2')}>
+            <div className="redirect-label-class-four" {...getAnalyticsLabelAttribute('h2')}>
               <h1>heading1</h1>
-              <h2 {...getAnalyticslabelAttribute('.text-content')}>
+              <h2 {...getAnalyticsLabelAttribute('.text-content')}>
                 <span className="text-content">content inside header</span>
                 <span>other content</span>
               </h2>
             </div>
-            <div className="redirect-label-class-five" {...getAnalyticslabelAttribute('h2')}>
+            <div className="redirect-label-class-five" {...getAnalyticsLabelAttribute('h2')}>
               <h1>heading1</h1>
-              <h2 {...getAnalyticslabelAttribute('.wonrg-text-content')}>
+              <h2 {...getAnalyticsLabelAttribute('.wonrg-text-content')}>
                 <span className="text-content">content inside header</span>
                 <span>other content</span>
               </h2>

--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -1,0 +1,228 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getLabelFromElement, processLabel } from '../labels-utils';
+import { getAnalyticsMetadataAttribute, getAnalyticslabelAttribute } from '../attributes';
+
+describe('getLabelFromElement', () => {
+  test('returns an empty string if the element is null', () => {
+    expect(getLabelFromElement(null)).toEqual('');
+  });
+  test('returns text content', () => {
+    const { container } = render(
+      <div>
+        <div id="target1">content</div>
+        <div id="target2">
+          <span>text 1</span>
+          <span>text 2</span>
+        </div>
+      </div>
+    );
+    const target1 = container.querySelector('#target1');
+    expect(getLabelFromElement(target1 as HTMLElement)).toEqual('content');
+    const target2 = container.querySelector('#target2');
+    expect(getLabelFromElement(target2 as HTMLElement)).toEqual('text 1text 2');
+  });
+  test('returns aria-label if defined', () => {
+    const { container } = render(
+      <div>
+        <div id="target" aria-label="returned label" aria-labelledby="id:r55:">
+          content
+        </div>
+        <div id="id:r55:" aria-label="labelled by label">
+          content
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('returned label');
+  });
+  test('returns aria label of aria-labelledby element', () => {
+    const { container } = render(
+      <div>
+        <div id="target" aria-labelledby="id:r55:">
+          content
+        </div>
+        <div id="id:r55:" aria-label="labelled by label">
+          content
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('labelled by label');
+  });
+  test('returns text content of aria-labelledby element', () => {
+    const { container } = render(
+      <div>
+        <div id="target" aria-labelledby="id:r55:">
+          content
+        </div>
+        <div id="id:r55:">second content</div>
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('second content');
+  });
+  test('returns text content of first aria-labelledby element', () => {
+    const { container } = render(
+      <div>
+        <div id="target" aria-labelledby="id:r55: id:r56:">
+          content
+        </div>
+        <div id="id:r55:">second content</div>
+        <div id="id:r56:">third content</div>
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('second content');
+  });
+  test('returns empty string if aria-labelledby element does not exist', () => {
+    const { container } = render(
+      <div>
+        <div id="target" aria-labelledby="id:r55: id:r56:">
+          content
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('');
+  });
+});
+
+describe('processLabel', () => {
+  test('returns an empty string when element and/or identifier are null', () => {
+    const { container } = render(
+      <div>
+        <div id="target">content</div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+
+    expect(processLabel(null, null)).toEqual('');
+    expect(processLabel(target, null)).toEqual('');
+    expect(processLabel(null, 'selector')).toEqual('');
+  });
+  test('returns an empty string when the selector cannot be resolved to an element', () => {
+    const { container } = render(
+      <div>
+        <div id="target">content</div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+
+    expect(processLabel(target, 'invalid-selector')).toEqual('');
+  });
+  test('returns node label when selector is an empty string', () => {
+    const { container } = render(
+      <div>
+        <div id="target">content</div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+
+    expect(processLabel(target, '')).toEqual('content');
+    expect(processLabel(target, { selector: '' })).toEqual('content');
+  });
+  test('returns node label when selector is an empty string', () => {
+    const { container } = render(
+      <div>
+        <div id="target">
+          <div>content</div>
+          <div className="label-class">
+            <div>second content</div>
+            <h1>label to return</h1>
+          </div>
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+
+    expect(processLabel(target, '.label-class h1')).toEqual('label to return');
+    expect(processLabel(target, { selector: '.label-class h1' })).toEqual('label to return');
+  });
+  test('returns first available label when selector is an array', () => {
+    const { container } = render(
+      <div>
+        <div id="target">
+          <div>content</div>
+          <div className="label-class">
+            <div>second content</div>
+            <h1>heading1</h1>
+            <h2></h2>
+            <h3>heading3</h3>
+          </div>
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+
+    expect(processLabel(target, { selector: ['.label-class h1', '.label-class h2', '.label-class h3'] })).toEqual(
+      'heading1'
+    );
+    expect(
+      processLabel(target, { selector: ['.label-wrong-class h1', '.label-wrong-class h2', '.label-class h3'] })
+    ).toEqual('heading3');
+    expect(processLabel(target, { selector: ['.label-class h2', '.label-class h3'] })).toEqual('heading3');
+  });
+  test('respects the root property', () => {
+    const { container } = render(
+      <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })}>
+        <div className="label-class">outer label</div>
+        <div id="target">
+          <div className="label-class">inner label</div>
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+
+    expect(processLabel(target, { selector: '.label-class', root: 'self' })).toEqual('inner label');
+    expect(processLabel(target, { selector: '.label-class', root: 'component' })).toEqual('outer label');
+  });
+
+  test('forwards the label resolution with data-awsui-analytics-label', () => {
+    const { container } = render(
+      <div>
+        <div {...getAnalyticsMetadataAttribute({ component: { name: 'FirstComponentName' } })}>
+          <div id="target1">
+            <div className="redirect-label-class-one" {...getAnalyticslabelAttribute('#target2 .label-class')}>
+              <div id="target2">
+                <div className="label-class">second inner label</div>
+              </div>
+            </div>
+            <div className="redirect-label-class-two" {...getAnalyticslabelAttribute('h1')}>
+              <h1>heading1</h1>
+              <h2>heading2</h2>
+            </div>
+            <div className="redirect-label-class-three" {...getAnalyticslabelAttribute('')}>
+              <h1>heading1</h1>
+              <h2>heading2</h2>
+            </div>
+            <div className="redirect-label-class-four" {...getAnalyticslabelAttribute('h2')}>
+              <h1>heading1</h1>
+              <h2 {...getAnalyticslabelAttribute('.text-content')}>
+                <span className="text-content">content inside header</span>
+                <span>other content</span>
+              </h2>
+            </div>
+            <div className="redirect-label-class-five" {...getAnalyticslabelAttribute('h2')}>
+              <h1>heading1</h1>
+              <h2 {...getAnalyticslabelAttribute('.wonrg-text-content')}>
+                <span className="text-content">content inside header</span>
+                <span>other content</span>
+              </h2>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target1') as HTMLElement;
+
+    expect(processLabel(target, '.redirect-label-class-one')).toEqual('second inner label');
+    expect(processLabel(target, '.redirect-label-class-two')).toEqual('heading1');
+    expect(processLabel(target, '.redirect-label-class-three')).toEqual('heading1heading2');
+    expect(processLabel(target, '.redirect-label-class-four')).toEqual('content inside header');
+    expect(processLabel(target, '.redirect-label-class-five')).toEqual('');
+  });
+});

--- a/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
+++ b/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GeneratedAnalyticsMetadataFragment } from '../interfaces';
+import { merge, mergeMetadata, processMetadata } from '../metadata-utils';
+
+jest.mock('../labels-utils', () => ({
+  processLabel: (node: HTMLElement | null, label: string) => `processed-${label}`,
+}));
+
+describe('processMetadata', () => {
+  test('recursively identifies elements ending with "label"', () => {
+    expect(processMetadata(null, { label: 'a', entry: { columnLabel: 'b', notLabelEnding: 'c' } })).toEqual({
+      label: 'processed-a',
+      entry: { columnLabel: 'processed-b', notLabelEnding: 'c' },
+    });
+  });
+});
+
+describe('merge', () => {
+  test('returns target when source is null', () => {
+    const target = { one: { three: 'three' } };
+    expect(merge(target, null)).toEqual(target);
+  });
+  test('returns source when target is null', () => {
+    const source = { one: { three: 'three' } };
+    expect(merge(null, source)).toEqual(source);
+  });
+  test('returns empty objet when both source and target are null', () => {
+    expect(merge(null, null)).toEqual({});
+  });
+  test('merges keys when not defined in target', () => {
+    const source = { one: { two: 'two' }, three: 'three' };
+    const target = { six: { seven: 'seven' }, eight: 'eight' };
+    expect(merge(target, source)).toEqual({ ...source, ...target });
+  });
+  test('overrides string values recursively', () => {
+    const source = { one: { two: 'two' }, three: 'three' };
+    const target = { one: { two: 'two-old' }, three: 'three-old' };
+    expect(merge(target, source)).toEqual(source);
+  });
+  test('recursively merges keys when not defined in nested target', () => {
+    const source = { one: { two: 'two' } };
+    const target = { one: { three: 'three' } };
+    expect(merge(target, source)).toEqual({ one: { two: 'two', three: 'three' } });
+  });
+});
+
+describe('mergeMetadata', () => {
+  test('returns empty object when both arguments are null', () => {
+    expect(mergeMetadata(null, null)).toEqual({});
+  });
+  test('adds component to empty context', () => {
+    const componentMetadata = { component: { name: 'ComponentName', label: 'label' } };
+    expect(mergeMetadata(null, componentMetadata)).toEqual({
+      contexts: [{ type: 'component', detail: componentMetadata.component }],
+    });
+  });
+  test('adds component to existing context as first element', () => {
+    const contexts: GeneratedAnalyticsMetadataFragment['contexts'] = [
+      { type: 'component', detail: { name: 'c1', label: 'label' } },
+    ];
+    const componentMetadata = { component: { name: 'ComponentName', label: 'label' } };
+    expect(mergeMetadata({ contexts }, componentMetadata)).toEqual({
+      contexts: [...contexts, { type: 'component', detail: componentMetadata.component }],
+    });
+  });
+  test('does not add component to contexts if component name is not specified', () => {
+    const componentMetadata = { component: { label: 'label' } };
+    expect(mergeMetadata(null, componentMetadata)).toEqual(componentMetadata);
+  });
+});

--- a/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
+++ b/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
@@ -44,6 +44,11 @@ describe('merge', () => {
     const target = { one: { three: 'three' } };
     expect(merge(target, source)).toEqual({ one: { two: 'two', three: 'three' } });
   });
+  test('copies arrays in target', () => {
+    const source = { two: 'two' };
+    const target = { one: ['three', 'four'] };
+    expect(merge(target, source)).toEqual({ one: ['three', 'four'], two: 'two' });
+  });
 });
 
 describe('mergeMetadata', () => {

--- a/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
+++ b/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
@@ -26,7 +26,7 @@ describe('merge', () => {
     const source = { one: { three: 'three' } };
     expect(merge(null, source)).toEqual(source);
   });
-  test('returns empty objet when both source and target are null', () => {
+  test('returns empty object when both source and target are null', () => {
     expect(merge(null, null)).toEqual({});
   });
   test('merges keys when not defined in target', () => {
@@ -61,7 +61,7 @@ describe('mergeMetadata', () => {
       contexts: [{ type: 'component', detail: componentMetadata.component }],
     });
   });
-  test('adds component to existing context as first element', () => {
+  test('adds component to existing context as last element', () => {
     const contexts: GeneratedAnalyticsMetadataFragment['contexts'] = [
       { type: 'component', detail: { name: 'c1', label: 'label' } },
     ];

--- a/src/internal/analytics-metadata/attributes.ts
+++ b/src/internal/analytics-metadata/attributes.ts
@@ -16,6 +16,6 @@ export const copyAnalyticsMetadataAttribute = (props: any) => ({
   [METADATA_ATTRIBUTE]: props[METADATA_ATTRIBUTE],
 });
 
-export const getAnalyticslabelAttribute = (labelIdentifierString: string) => ({
+export const getAnalyticsLabelAttribute = (labelIdentifierString: string) => ({
   [LABEL_ATTRIBUTE]: labelIdentifierString,
 });

--- a/src/internal/analytics-metadata/attributes.ts
+++ b/src/internal/analytics-metadata/attributes.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GeneratedAnalyticsMetadataFragment } from './interfaces';
+
+export const METADATA_DATA_ATTRIBUTE = 'awsuiAnalytics';
+export const METADATA_ATTRIBUTE = `data-awsui-analytics`;
+export const LABEL_DATA_ATTRIBUTE = 'awsuiAnalyticsLabel';
+const LABEL_ATTRIBUTE = 'data-awsui-analytics-label';
+
+export const getAnalyticsMetadataAttribute = (metadata: GeneratedAnalyticsMetadataFragment) => ({
+  [METADATA_ATTRIBUTE]: JSON.stringify(metadata),
+});
+
+export const copyAnalyticsMetadataAttribute = (props: any) => ({
+  [METADATA_ATTRIBUTE]: props[METADATA_ATTRIBUTE],
+});
+
+export const getAnalyticslabelAttribute = (labelIdentifierString: string) => ({
+  [LABEL_ATTRIBUTE]: labelIdentifierString,
+});

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -3,7 +3,7 @@
 
 import { METADATA_DATA_ATTRIBUTE } from './attributes';
 
-export const findNextNode = (node: HTMLElement): HTMLElement | null => {
+export const findLogicalParent = (node: HTMLElement): HTMLElement | null => {
   try {
     const referrer = node.dataset.awsuiReferrerId;
     if (referrer) {
@@ -18,7 +18,7 @@ export const findNextNode = (node: HTMLElement): HTMLElement | null => {
 export function findComponentUp(node: HTMLElement | null): HTMLElement | null {
   let firstComponentElement = node;
   while (firstComponentElement && firstComponentElement.tagName !== 'body' && !isNodeComponent(firstComponentElement)) {
-    firstComponentElement = findNextNode(firstComponentElement);
+    firstComponentElement = findLogicalParent(firstComponentElement);
   }
   return firstComponentElement && firstComponentElement.tagName !== 'body' ? firstComponentElement : null;
 }

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { METADATA_DATA_ATTRIBUTE } from './attributes';
+
+export const findNextNode = (node: HTMLElement): HTMLElement | null => {
+  try {
+    const referrer = node.dataset.awsuiReferrerId;
+    if (referrer) {
+      return document.querySelector(`[id="${referrer}"]`);
+    }
+    return node.parentElement;
+  } catch (ex) {
+    return null;
+  }
+};
+
+export function findComponentUp(node: HTMLElement | null): HTMLElement | null {
+  let firstComponentElement = node;
+  while (
+    firstComponentElement &&
+    firstComponentElement?.tagName !== 'body' &&
+    !isNodeComponent(firstComponentElement)
+  ) {
+    firstComponentElement = findNextNode(firstComponentElement);
+  }
+  return firstComponentElement && firstComponentElement.tagName !== 'body' ? firstComponentElement : null;
+}
+
+export const isNodeComponent = (node: HTMLElement): boolean => {
+  const metadataString = node.dataset[METADATA_DATA_ATTRIBUTE] || '{}';
+  try {
+    const metadata = JSON.parse(metadataString);
+    return !!metadata.component && !!metadata.component.name;
+  } catch (ex) {
+    return false;
+  }
+};

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -17,18 +17,17 @@ export const findNextNode = (node: HTMLElement): HTMLElement | null => {
 
 export function findComponentUp(node: HTMLElement | null): HTMLElement | null {
   let firstComponentElement = node;
-  while (
-    firstComponentElement &&
-    firstComponentElement?.tagName !== 'body' &&
-    !isNodeComponent(firstComponentElement)
-  ) {
+  while (firstComponentElement && firstComponentElement.tagName !== 'body' && !isNodeComponent(firstComponentElement)) {
     firstComponentElement = findNextNode(firstComponentElement);
   }
   return firstComponentElement && firstComponentElement.tagName !== 'body' ? firstComponentElement : null;
 }
 
 export const isNodeComponent = (node: HTMLElement): boolean => {
-  const metadataString = node.dataset[METADATA_DATA_ATTRIBUTE] || '{}';
+  const metadataString = node.dataset[METADATA_DATA_ATTRIBUTE];
+  if (!metadataString) {
+    return false;
+  }
   try {
     const metadata = JSON.parse(metadataString);
     return !!metadata.component && !!metadata.component.name;

--- a/src/internal/analytics-metadata/index.ts
+++ b/src/internal/analytics-metadata/index.ts
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { GeneratedAnalyticsMetadataFragment, GeneratedAnalyticsMetadata } from './interfaces';
+export {
+  getAnalyticsMetadataAttribute,
+  copyAnalyticsMetadataAttribute,
+  getAnalyticslabelAttribute,
+} from './attributes';
+
+import { METADATA_DATA_ATTRIBUTE } from './attributes';
+import { GeneratedAnalyticsMetadata, GeneratedAnalyticsMetadataFragment } from './interfaces';
+import { findNextNode } from './dom-utils';
+import { mergeMetadata, processMetadata } from './metadata-utils';
+
+export const getGeneratedAnalyticsMetadata = (target: HTMLElement | null): GeneratedAnalyticsMetadata => {
+  let metadata: GeneratedAnalyticsMetadataFragment = {};
+  let currentNode = target;
+  while (currentNode && currentNode.tagName !== 'body') {
+    try {
+      const currentMetadataString = currentNode.dataset[METADATA_DATA_ATTRIBUTE];
+      if (currentMetadataString) {
+        const currentMetadata = JSON.parse(currentMetadataString);
+        metadata = mergeMetadata(metadata, processMetadata(currentNode, currentMetadata));
+      }
+    } catch (ex) {
+      /* empty */
+    } finally {
+      currentNode = findNextNode(currentNode);
+    }
+  }
+  return metadata as GeneratedAnalyticsMetadata;
+};

--- a/src/internal/analytics-metadata/index.ts
+++ b/src/internal/analytics-metadata/index.ts
@@ -5,12 +5,12 @@ export { GeneratedAnalyticsMetadataFragment, GeneratedAnalyticsMetadata } from '
 export {
   getAnalyticsMetadataAttribute,
   copyAnalyticsMetadataAttribute,
-  getAnalyticslabelAttribute,
+  getAnalyticsLabelAttribute,
 } from './attributes';
 
 import { METADATA_DATA_ATTRIBUTE } from './attributes';
 import { GeneratedAnalyticsMetadata, GeneratedAnalyticsMetadataFragment } from './interfaces';
-import { findNextNode } from './dom-utils';
+import { findLogicalParent } from './dom-utils';
 import { mergeMetadata, processMetadata } from './metadata-utils';
 
 export const getGeneratedAnalyticsMetadata = (target: HTMLElement | null): GeneratedAnalyticsMetadata => {
@@ -26,7 +26,7 @@ export const getGeneratedAnalyticsMetadata = (target: HTMLElement | null): Gener
     } catch (ex) {
       /* empty */
     } finally {
-      currentNode = findNextNode(currentNode);
+      currentNode = findLogicalParent(currentNode);
     }
   }
   return metadata as GeneratedAnalyticsMetadata;

--- a/src/internal/analytics-metadata/interfaces.ts
+++ b/src/internal/analytics-metadata/interfaces.ts
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export interface GeneratedAnalyticsMetadata {
+  // action that the user performs. For example: "select".
+  action: string;
+
+  //detail of the action. For example: label and href of a link
+  detail: Record<string, string>;
+
+  // array of contexts in which the interaction happened, starting from the component and going up in the hierarchy of components
+  contexts: Array<GeneratedAnalyticsMetadataComponentContext>;
+}
+
+interface GeneratedAnalyticsMetadataComponent {
+  // name of the component. For example: "awsui.RadioGroup". We prefix the actual name with awsui to account for future tagging of custom components
+  name: string;
+
+  // captured label of the component. For example: label of the input field
+  label: string;
+
+  // some components offer this property to identify them
+  instanceIdentifier?: string;
+
+  // relevant properties of the component. For example: {variant: 'primary'} for Button, {external: 'true', href: '...'} for Link
+  properties?: Record<string, string>;
+
+  // relevant information on the specific area of the component in which the interaction happened
+  innerContext?: Record<string, string>;
+}
+
+interface GeneratedAnalyticsMetadataComponentContext {
+  type: 'component';
+  detail: GeneratedAnalyticsMetadataComponent;
+}
+
+export interface LabelIdentifier {
+  selector: string | Array<string>;
+  root?: 'component' | 'self';
+}
+
+export interface GeneratedAnalyticsMetadataFragment extends Omit<Partial<GeneratedAnalyticsMetadata>, 'detail'> {
+  detail?: Record<string, string | LabelIdentifier>;
+  component?: Omit<Partial<GeneratedAnalyticsMetadataComponent>, 'innerContext' | 'label'> & {
+    label?: string | LabelIdentifier;
+    innerContext?: Record<string, string | LabelIdentifier>;
+  };
+}

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -64,5 +64,5 @@ export const getLabelFromElement = (element: HTMLElement | null): string => {
     return getLabelFromElement(elementWithLabel as HTMLElement);
   }
 
-  return element?.textContent || '';
+  return element.textContent || '';
 };

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { LABEL_DATA_ATTRIBUTE } from './attributes';
+import { findComponentUp } from './dom-utils';
+import { LabelIdentifier } from './interfaces';
+
+export const processLabel = (node: HTMLElement | null, labelIdentifier: string | LabelIdentifier | null): string => {
+  if (labelIdentifier === null) {
+    return '';
+  }
+  const formattedLabelIdentifier = formatLabelIdentifier(labelIdentifier);
+  const selector = formattedLabelIdentifier.selector;
+  if (Array.isArray(selector)) {
+    for (const labelSelector of selector) {
+      const label = processSingleLabel(node, labelSelector, formattedLabelIdentifier.root);
+      if (label) {
+        return label;
+      }
+    }
+  }
+  return processSingleLabel(node, selector as string, formattedLabelIdentifier.root);
+};
+
+const formatLabelIdentifier = (labelIdentifier: string | LabelIdentifier): LabelIdentifier => {
+  if (typeof labelIdentifier === 'string') {
+    return { selector: labelIdentifier };
+  }
+  return labelIdentifier;
+};
+
+const processSingleLabel = (
+  node: HTMLElement | null,
+  labelSelector: string,
+  root: LabelIdentifier['root'] = 'self'
+): string => {
+  if (!node) {
+    return '';
+  }
+  if (root === 'component') {
+    return processSingleLabel(findComponentUp(node), labelSelector);
+  }
+  let labelElement: HTMLElement | null = node;
+  if (labelSelector) {
+    labelElement = labelElement.querySelector(labelSelector) as HTMLElement | null;
+  }
+  if (labelElement && labelElement.dataset[LABEL_DATA_ATTRIBUTE]) {
+    return processLabel(labelElement, labelElement.dataset[LABEL_DATA_ATTRIBUTE]);
+  }
+  return getLabelFromElement(labelElement);
+};
+
+export const getLabelFromElement = (element: HTMLElement | null): string => {
+  if (!element) {
+    return '';
+  }
+  const ariaLabel = element.getAttribute('aria-label');
+  if (ariaLabel) {
+    return ariaLabel;
+  }
+  const ariaLabelledBy = element.getAttribute('aria-labelledby');
+  if (ariaLabelledBy) {
+    const elementWithLabel = document.querySelector(`[id="${ariaLabelledBy.split(' ')[0]}"]`);
+    return getLabelFromElement(elementWithLabel as HTMLElement);
+  }
+
+  return element?.textContent || '';
+};

--- a/src/internal/analytics-metadata/metadata-utils.ts
+++ b/src/internal/analytics-metadata/metadata-utils.ts
@@ -1,0 +1,51 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GeneratedAnalyticsMetadataFragment } from './interfaces';
+import { processLabel } from './labels-utils';
+
+export const mergeMetadata = (
+  metadata: GeneratedAnalyticsMetadataFragment | null,
+  localMetadata: GeneratedAnalyticsMetadataFragment | null
+) => {
+  const output = merge(metadata, localMetadata);
+  if (output.component && output.component.name) {
+    output.contexts = [...(output.contexts || []), { type: 'component', detail: output.component }];
+    delete output.component;
+  }
+  return output;
+};
+
+export const processMetadata = (node: HTMLElement | null, localMetadata: any): GeneratedAnalyticsMetadataFragment => {
+  return Object.keys(localMetadata).reduce((acc: any, key: string) => {
+    if (key.toLowerCase().match(/label$/)) {
+      acc[key] = processLabel(node, localMetadata[key]);
+    } else if (typeof localMetadata[key] !== 'string') {
+      acc[key] = processMetadata(node, localMetadata[key]);
+    } else {
+      acc[key] = localMetadata[key];
+    }
+    return acc;
+  }, {});
+};
+
+export const merge = (inputTarget: any, inputSource: any): any => {
+  const merged: any = {};
+  const target = inputTarget || {};
+  const source = inputSource || {};
+  const targetKeys = Object.keys(target);
+  const sourceKeys = Object.keys(source);
+  const allKeys = new Set([...targetKeys, ...sourceKeys]);
+  for (const key of allKeys) {
+    if (target[key] && !source[key]) {
+      merged[key] = target[key];
+    } else if (!target[key] && source[key]) {
+      merged[key] = source[key];
+    } else if (typeof target[key] === 'string') {
+      merged[key] = source[key];
+    } else {
+      merged[key] = merge(target[key], source[key]);
+    }
+  }
+  return JSON.parse(JSON.stringify(merged));
+};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -27,3 +27,11 @@ export {
 } from './direction';
 export { useFocusVisible } from './focus-visible';
 export { KeyCode, isModifierKey } from './keycode';
+export {
+  GeneratedAnalyticsMetadataFragment,
+  GeneratedAnalyticsMetadata,
+  getAnalyticsMetadataAttribute,
+  copyAnalyticsMetadataAttribute,
+  getAnalyticslabelAttribute,
+  getGeneratedAnalyticsMetadata,
+} from './analytics-metadata';

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -32,6 +32,6 @@ export {
   GeneratedAnalyticsMetadata,
   getAnalyticsMetadataAttribute,
   copyAnalyticsMetadataAttribute,
-  getAnalyticslabelAttribute,
+  getAnalyticsLabelAttribute,
   getGeneratedAnalyticsMetadata,
 } from './analytics-metadata';


### PR DESCRIPTION
Partial implementation of internal utilities for enhanced analytics metadata injection and collection.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
