### PR TITLE
chore: Add additional focus-visible mixin to support "fake" focus

### DIFF
--- a/src/internal/focus-visible/index.scss
+++ b/src/internal/focus-visible/index.scss
@@ -11,3 +11,10 @@
     @content;
   }
 }
+
+@mixin when-visible-unfocused {
+  // stylelint-disable-next-line selector-combinator-disallowed-list
+  body[data-awsui-focus-visible='true'] & {
+    @content;
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This allows `focus-visible` to be used in places where we manually override focus (e.g. because a different element is focused than the one we want to actually show the focus ring around: https://github.com/cloudscape-design/components/blob/main/src/file-upload/file-input/styles.scss#L25)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
