### PR TITLE
feat: Add method for testing purposes

### DIFF
--- a/src/internal/analytics-metadata/__tests__/test-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/test-utils.test.tsx
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getRawAnalyticsMetadata } from '../test-utils';
+import { METADATA_ATTRIBUTE } from '../attributes';
+import { ComponentOne, ComponentThree } from './components';
+
+describe('getRawAnalyticsMetadata', () => {
+  test('returns metadata and labels', () => {
+    const { container } = render(<ComponentThree />);
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(getRawAnalyticsMetadata(target)).toEqual({
+      metadata: [
+        {
+          action: 'select',
+          detail: {
+            label: {
+              selector: ['.event-label', '.second-event-label'],
+              root: 'component',
+            },
+            keyTwo: 'valueTwo',
+          },
+        },
+        {
+          detail: {
+            keyOne: 'valueOne',
+            keyTwo: 'overriddenValueTwo',
+          },
+        },
+        {
+          component: {
+            name: 'ComponentOne',
+            label: '.component-label',
+            properties: {
+              multi: 'true',
+            },
+          },
+        },
+        {
+          component: {
+            name: 'ComponentTwo',
+            label: '.component-label',
+          },
+        },
+        {
+          component: {
+            innerContext: {
+              position: '2',
+              columnLabel: {
+                selector: '.invalid-selector',
+                root: 'self',
+              },
+            },
+          },
+        },
+        {
+          component: {
+            name: 'ComponentThree',
+          },
+        },
+      ],
+      labelSelectors: [
+        '.event-label',
+        '.second-event-label',
+        '.component-label',
+        '.component-label',
+        '.invalid-selector',
+      ],
+    });
+  });
+  test('skips malformed metadata', () => {
+    const { container } = render(
+      <div {...{ [METADATA_ATTRIBUTE]: "{'corruptedJSON':}" }}>
+        <ComponentOne malformed={true} />
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(getRawAnalyticsMetadata(target)).toEqual({
+      metadata: [
+        {
+          action: 'select',
+          detail: {
+            label: { selector: ['.event-label', '.second-event-label'], root: 'component' },
+            keyTwo: 'valueTwo',
+          },
+        },
+        {
+          component: { name: 'ComponentOne', label: '.component-label', properties: { multi: 'true' } },
+        },
+      ],
+      labelSelectors: ['.event-label', '.second-event-label', '.component-label'],
+    });
+  });
+});

--- a/src/internal/analytics-metadata/index.ts
+++ b/src/internal/analytics-metadata/index.ts
@@ -7,6 +7,7 @@ export {
   copyAnalyticsMetadataAttribute,
   getAnalyticsLabelAttribute,
 } from './attributes';
+export { getRawAnalyticsMetadata } from './test-utils';
 
 import { METADATA_DATA_ATTRIBUTE } from './attributes';
 import { GeneratedAnalyticsMetadata, GeneratedAnalyticsMetadataFragment } from './interfaces';

--- a/src/internal/analytics-metadata/index.ts
+++ b/src/internal/analytics-metadata/index.ts
@@ -17,7 +17,7 @@ import { mergeMetadata, processMetadata } from './metadata-utils';
 export const getGeneratedAnalyticsMetadata = (target: HTMLElement | null): GeneratedAnalyticsMetadata => {
   let metadata: GeneratedAnalyticsMetadataFragment = {};
   let currentNode = target;
-  while (currentNode && currentNode.tagName !== 'body') {
+  while (currentNode) {
     try {
       const currentMetadataString = currentNode.dataset[METADATA_DATA_ATTRIBUTE];
       if (currentMetadataString) {

--- a/src/internal/analytics-metadata/test-utils.ts
+++ b/src/internal/analytics-metadata/test-utils.ts
@@ -15,7 +15,7 @@ export const getRawAnalyticsMetadata = (target: HTMLElement | null): RawAnalytic
     labelSelectors: [],
   };
   let currentNode = target;
-  while (currentNode && currentNode.tagName !== 'body') {
+  while (currentNode) {
     try {
       const currentMetadataString = currentNode.dataset[METADATA_DATA_ATTRIBUTE];
       if (currentMetadataString) {
@@ -33,9 +33,9 @@ export const getRawAnalyticsMetadata = (target: HTMLElement | null): RawAnalytic
 };
 
 const getLabelSelectors = (localMetadata: any): Array<string> => {
-  return Object.keys(localMetadata).reduce((acc: any, key: string) => {
+  return Object.keys(localMetadata).reduce((acc: Array<string>, key: string) => {
     if (key.toLowerCase().match(/label$/)) {
-      acc = [...acc, ...getSelectorsFromLabel(localMetadata[key])];
+      acc = [...acc, ...getLabelSelectorsFromLabelIdentifier(localMetadata[key])];
     } else if (typeof localMetadata[key] !== 'string') {
       acc = [...acc, ...getLabelSelectors(localMetadata[key])];
     }
@@ -43,7 +43,7 @@ const getLabelSelectors = (localMetadata: any): Array<string> => {
   }, []);
 };
 
-const getSelectorsFromLabel = (label: string | LabelIdentifier): Array<string> => {
+const getLabelSelectorsFromLabelIdentifier = (label: string | LabelIdentifier): Array<string> => {
   if (typeof label === 'string') {
     return [label];
   } else if (typeof label.selector === 'string') {

--- a/src/internal/analytics-metadata/test-utils.ts
+++ b/src/internal/analytics-metadata/test-utils.ts
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { METADATA_DATA_ATTRIBUTE } from './attributes';
+import { GeneratedAnalyticsMetadataFragment, LabelIdentifier } from './interfaces';
+import { findLogicalParent } from './dom-utils';
+
+interface RawAnalyticsMetadata {
+  metadata: Array<GeneratedAnalyticsMetadataFragment>;
+  labelSelectors: Array<string>;
+}
+export const getRawAnalyticsMetadata = (target: HTMLElement | null): RawAnalyticsMetadata => {
+  const output: RawAnalyticsMetadata = {
+    metadata: [],
+    labelSelectors: [],
+  };
+  let currentNode = target;
+  while (currentNode && currentNode.tagName !== 'body') {
+    try {
+      const currentMetadataString = currentNode.dataset[METADATA_DATA_ATTRIBUTE];
+      if (currentMetadataString) {
+        const currentMetadata = JSON.parse(currentMetadataString);
+        output.metadata.push(currentMetadata);
+        output.labelSelectors = [...output.labelSelectors, ...getLabelSelectors(currentMetadata)];
+      }
+    } catch (ex) {
+      /* empty */
+    } finally {
+      currentNode = findLogicalParent(currentNode);
+    }
+  }
+  return output;
+};
+
+const getLabelSelectors = (localMetadata: any): Array<string> => {
+  return Object.keys(localMetadata).reduce((acc: any, key: string) => {
+    if (key.toLowerCase().match(/label$/)) {
+      acc = [...acc, ...getSelectorsFromLabel(localMetadata[key])];
+    } else if (typeof localMetadata[key] !== 'string') {
+      acc = [...acc, ...getLabelSelectors(localMetadata[key])];
+    }
+    return acc;
+  }, []);
+};
+
+const getSelectorsFromLabel = (label: string | LabelIdentifier): Array<string> => {
+  if (typeof label === 'string') {
+    return [label];
+  } else if (typeof label.selector === 'string') {
+    return [label.selector];
+  }
+  return label.selector;
+};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -34,4 +34,5 @@ export {
   copyAnalyticsMetadataAttribute,
   getAnalyticsLabelAttribute,
   getGeneratedAnalyticsMetadata,
+  getRawAnalyticsMetadata,
 } from './analytics-metadata';


### PR DESCRIPTION
*Description of changes:*

Additional method to allow for testing of the analytics metadata. For example, it will allow to test that component names have a certain prefix, and that class names used for labels are part of a certain set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
