### PR TITLE
chore: Move global flags management from component to toolkit

### DIFF
--- a/src/internal/global-flags/__tests__/global-flags-ssr.test.ts
+++ b/src/internal/global-flags/__tests__/global-flags-ssr.test.ts
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable header/header */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import * as globalFlags from '../';
+import { awsuiGlobalFlagsSymbol, FlagsHolder } from '../';
+const { getGlobalFlag } = globalFlags;
+
+declare const global: typeof globalThis & FlagsHolder;
+
+afterEach(() => {
+  delete global[awsuiGlobalFlagsSymbol];
+});
+
+describe('getGlobalFlag', () => {
+  test('ensure no window in this environment', () => {
+    expect(typeof window === 'undefined').toBe(true);
+  });
+
+  test('returns undefined if the global flags object does not exist', () => {
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
+  });
+  test('returns undefined if the global flags object exists but the flag is not set', () => {
+    global[awsuiGlobalFlagsSymbol] = {};
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
+  });
+  test('returns appLayoutWidget value when defined', () => {
+    global[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+    global[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+});

--- a/src/internal/global-flags/__tests__/global-flags.test.ts
+++ b/src/internal/global-flags/__tests__/global-flags.test.ts
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as globalFlags from '../';
+import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../';
+const { getGlobalFlag } = globalFlags;
+
+declare const window: Window & FlagsHolder;
+
+afterEach(() => {
+  delete window[awsuiGlobalFlagsSymbol];
+  jest.restoreAllMocks();
+});
+
+describe('getGlobalFlag', () => {
+  test('returns undefined if the global flags object does not exist', () => {
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
+  });
+  test('returns undefined if the global flags object exists but the flag is not set', () => {
+    window[awsuiGlobalFlagsSymbol] = {};
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
+  });
+  test('returns appLayoutWidget value when defined', () => {
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+    window[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('returns appLayoutWidget value when defined in top window', () => {
+    jest
+      .spyOn(globalFlags, 'getTopWindow')
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: true } } as typeof window);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+    jest.restoreAllMocks();
+
+    jest
+      .spyOn(globalFlags, 'getTopWindow')
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: false } } as typeof window);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+  });
+  test('privileges values in the self window', () => {
+    jest
+      .spyOn(globalFlags, 'getTopWindow')
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: false } } as typeof window);
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('returns top window value when not defined in the self window', () => {
+    jest
+      .spyOn(globalFlags, 'getTopWindow')
+      .mockReturnValue({ [awsuiGlobalFlagsSymbol]: { appLayoutWidget: true } } as typeof window);
+    window[awsuiGlobalFlagsSymbol] = {};
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('returns undefined when top window is not available', () => {
+    jest.spyOn(globalFlags, 'getTopWindow').mockReturnValue(null);
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
+  });
+  test('returns undefined when an error is thrown and flag is not defined in own window', () => {
+    jest.spyOn(globalFlags, 'getTopWindow').mockImplementation(() => {
+      throw new Error('whatever');
+    });
+    expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
+  });
+  test('returns value when an error is thrown and flag is defined in own window', () => {
+    jest.spyOn(globalFlags, 'getTopWindow').mockImplementation(() => {
+      throw new Error('whatever');
+    });
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+});

--- a/src/internal/global-flags/index.ts
+++ b/src/internal/global-flags/index.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
+
+interface GlobalFlags {
+  appLayoutWidget?: boolean;
+}
+
+export interface FlagsHolder {
+  [awsuiGlobalFlagsSymbol]?: GlobalFlags;
+}
+
+export const getTopWindow = () => {
+  return window.top;
+};
+
+function getGlobal() {
+  return typeof window !== 'undefined' ? window : globalThis;
+}
+
+function readFlag(window: unknown, flagName: keyof GlobalFlags) {
+  const holder = window as FlagsHolder | null;
+  return holder?.[awsuiGlobalFlagsSymbol]?.[flagName];
+}
+
+export const getGlobalFlag = (flagName: keyof GlobalFlags): GlobalFlags[keyof GlobalFlags] | undefined => {
+  try {
+    const ownFlag = readFlag(getGlobal(), flagName);
+    if (ownFlag !== undefined) {
+      return ownFlag;
+    }
+    return readFlag(getTopWindow(), flagName);
+  } catch (e) {
+    return undefined;
+  }
+};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -27,3 +27,4 @@ export {
 } from './direction';
 export { useFocusVisible } from './focus-visible';
 export { KeyCode, isModifierKey } from './keycode';
+export { getGlobalFlag } from './global-flags';


### PR DESCRIPTION
To be able to use it to enable/disable analytics metadata decoration. Copied from https://github.com/cloudscape-design/components/blob/main/src/internal/utils/global-flags.ts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
