### PR TITLE
feat: Support configuring VR feature flag in SSR environment

### DIFF
--- a/src/internal/global-flags/__tests__/global-flags-ssr.test.ts
+++ b/src/internal/global-flags/__tests__/global-flags-ssr.test.ts
@@ -8,10 +8,10 @@ import * as globalFlags from '../';
 import { awsuiGlobalFlagsSymbol, FlagsHolder } from '../';
 const { getGlobalFlag } = globalFlags;
 
-declare const global: typeof globalThis & FlagsHolder;
+const globalWithFlags = globalThis as FlagsHolder;
 
 afterEach(() => {
-  delete global[awsuiGlobalFlagsSymbol];
+  delete globalWithFlags[awsuiGlobalFlagsSymbol];
 });
 
 describe('getGlobalFlag', () => {
@@ -23,13 +23,13 @@ describe('getGlobalFlag', () => {
     expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
   test('returns undefined if the global flags object exists but the flag is not set', () => {
-    global[awsuiGlobalFlagsSymbol] = {};
+    globalWithFlags[awsuiGlobalFlagsSymbol] = {};
     expect(getGlobalFlag('appLayoutWidget')).toBeUndefined();
   });
   test('returns appLayoutWidget value when defined', () => {
-    global[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    globalWithFlags[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
     expect(getGlobalFlag('appLayoutWidget')).toBe(false);
-    global[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
+    globalWithFlags[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
     expect(getGlobalFlag('appLayoutWidget')).toBe(true);
   });
 });

--- a/src/internal/global-flags/index.ts
+++ b/src/internal/global-flags/index.ts
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+export const awsuiVisualRefreshFlag = Symbol.for('awsui-visual-refresh-flag');
 export const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
 
 interface GlobalFlags {
@@ -8,19 +9,19 @@ interface GlobalFlags {
 }
 
 export interface FlagsHolder {
+  [awsuiVisualRefreshFlag]?: () => boolean;
   [awsuiGlobalFlagsSymbol]?: GlobalFlags;
 }
 
 export const getTopWindow = () => {
-  return window.top;
+  return window.top as FlagsHolder | null;
 };
 
-function getGlobal() {
-  return typeof window !== 'undefined' ? window : globalThis;
+export function getGlobal() {
+  return (typeof window !== 'undefined' ? window : globalThis) as FlagsHolder | null;
 }
 
-function readFlag(window: unknown, flagName: keyof GlobalFlags) {
-  const holder = window as FlagsHolder | null;
+function readFlag(holder: FlagsHolder | null, flagName: keyof GlobalFlags) {
   return holder?.[awsuiGlobalFlagsSymbol]?.[flagName];
 }
 

--- a/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.ssr.test.tsx
+++ b/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.ssr.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+/* eslint-disable header/header */
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+import React from 'react';
+import { useRuntimeVisualRefresh, clearVisualRefreshState } from '../index';
+import { clearMessageCache } from '../../logging';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { awsuiVisualRefreshFlag, FlagsHolder } from '../../global-flags';
+
+const globalWithFlags = globalThis as FlagsHolder;
+
+function App() {
+  const isRefresh = useRuntimeVisualRefresh();
+  return <div data-testid="current-mode">{isRefresh.toString()}</div>;
+}
+
+afterEach(() => {
+  delete globalWithFlags[awsuiVisualRefreshFlag];
+  jest.restoreAllMocks();
+  clearVisualRefreshState();
+  clearMessageCache();
+});
+
+test('resolves to classic by default', () => {
+  const content = renderToStaticMarkup(<App />);
+  expect(content).toEqual('<div data-testid="current-mode">false</div>');
+});
+
+test('supports setting visual refresh flag via globalThis', () => {
+  globalWithFlags[awsuiVisualRefreshFlag] = () => true;
+  const content = renderToStaticMarkup(<App />);
+  expect(content).toEqual('<div data-testid="current-mode">true</div>');
+});
+
+test('prints a warning when feature flag changes between renders', () => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  globalWithFlags[awsuiVisualRefreshFlag] = () => true;
+  renderToStaticMarkup(<App />);
+  globalWithFlags[awsuiVisualRefreshFlag] = () => false;
+  renderToStaticMarkup(<App />);
+  expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/Dynamic visual refresh change detected/));
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Support feature flags in SSR

```js
globalThis[Symbol.for('awsui-visual-refresh-flag')] = () => true
```

It was already working for other feature flags, but not for the main VR flag


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
