### PR TITLE
feat: Add global flags setter for testing purposes

### DIFF
--- a/src/internal/global-flags/__tests__/global-flags-ssr.test.ts
+++ b/src/internal/global-flags/__tests__/global-flags-ssr.test.ts
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import * as globalFlags from '../';
 import { awsuiGlobalFlagsSymbol, FlagsHolder } from '../';
-const { getGlobalFlag } = globalFlags;
+const { getGlobalFlag, setGlobalFlag } = globalFlags;
 
 const globalWithFlags = globalThis as FlagsHolder;
 
@@ -31,5 +31,33 @@ describe('getGlobalFlag', () => {
     expect(getGlobalFlag('appLayoutWidget')).toBe(false);
     globalWithFlags[awsuiGlobalFlagsSymbol].appLayoutWidget = true;
     expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+});
+
+describe('setGlobalFlag', () => {
+  test('sets value if global flag object exists', () => {
+    globalWithFlags[awsuiGlobalFlagsSymbol] = {};
+    setGlobalFlag('appLayoutWidget', true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+    setGlobalFlag('appLayoutWidget', false);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+  });
+  test('sets value if global flag object does not exist', () => {
+    setGlobalFlag('appLayoutWidget', true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('sets value if flag already exists', () => {
+    globalWithFlags[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    setGlobalFlag('appLayoutWidget', true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('does not create global flag object if value is undefined', () => {
+    setGlobalFlag('appLayoutWidget', undefined);
+    expect(globalWithFlags[awsuiGlobalFlagsSymbol]).toBeUndefined();
+  });
+  test('removes flag if value is undefined', () => {
+    globalWithFlags[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    setGlobalFlag('appLayoutWidget', undefined);
+    expect(Object.keys(globalWithFlags[awsuiGlobalFlagsSymbol]).length).toBe(0);
   });
 });

--- a/src/internal/global-flags/__tests__/global-flags.test.ts
+++ b/src/internal/global-flags/__tests__/global-flags.test.ts
@@ -3,7 +3,7 @@
 
 import * as globalFlags from '../';
 import { FlagsHolder, awsuiGlobalFlagsSymbol } from '../';
-const { getGlobalFlag } = globalFlags;
+const { getGlobalFlag, setGlobalFlag } = globalFlags;
 
 declare const window: Window & FlagsHolder;
 
@@ -68,5 +68,33 @@ describe('getGlobalFlag', () => {
     });
     window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: true };
     expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+});
+
+describe('setGlobalFlag', () => {
+  test('sets value if global flag object exists', () => {
+    window[awsuiGlobalFlagsSymbol] = {};
+    setGlobalFlag('appLayoutWidget', true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+    setGlobalFlag('appLayoutWidget', false);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(false);
+  });
+  test('sets value if global flag object does not exist', () => {
+    setGlobalFlag('appLayoutWidget', true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('sets value if flag already exists', () => {
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    setGlobalFlag('appLayoutWidget', true);
+    expect(getGlobalFlag('appLayoutWidget')).toBe(true);
+  });
+  test('does not create global flag object if value is undefined', () => {
+    setGlobalFlag('appLayoutWidget', undefined);
+    expect(window[awsuiGlobalFlagsSymbol]).toBeUndefined();
+  });
+  test('removes flag if value is undefined', () => {
+    window[awsuiGlobalFlagsSymbol] = { appLayoutWidget: false };
+    setGlobalFlag('appLayoutWidget', undefined);
+    expect(Object.keys(window[awsuiGlobalFlagsSymbol]).length).toBe(0);
   });
 });

--- a/src/internal/global-flags/index.ts
+++ b/src/internal/global-flags/index.ts
@@ -38,7 +38,10 @@ export const getGlobalFlag = (flagName: keyof GlobalFlags): GlobalFlags[keyof Gl
   }
 };
 
-export const setGlobalFlag = (flagName: keyof GlobalFlags, value: GlobalFlags[keyof GlobalFlags] | undefined) => {
+export const setGlobalFlag = <FlagName extends keyof GlobalFlags>(
+  flagName: FlagName,
+  value: GlobalFlags[FlagName] | undefined
+) => {
   const holder = getGlobal() as FlagsHolder;
   if (value === undefined) {
     const currentValue = readFlag(holder, flagName);

--- a/src/internal/global-flags/index.ts
+++ b/src/internal/global-flags/index.ts
@@ -37,3 +37,16 @@ export const getGlobalFlag = (flagName: keyof GlobalFlags): GlobalFlags[keyof Gl
     return undefined;
   }
 };
+
+export const setGlobalFlag = (flagName: keyof GlobalFlags, value: GlobalFlags[keyof GlobalFlags] | undefined) => {
+  const holder = getGlobal() as FlagsHolder;
+  if (value === undefined) {
+    const currentValue = readFlag(holder, flagName);
+    if (currentValue !== undefined) {
+      delete holder[awsuiGlobalFlagsSymbol]![flagName];
+    }
+  } else {
+    holder[awsuiGlobalFlagsSymbol] = holder[awsuiGlobalFlagsSymbol] || {};
+    holder[awsuiGlobalFlagsSymbol][flagName] = value;
+  }
+};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -27,4 +27,4 @@ export {
 } from './direction';
 export { useFocusVisible } from './focus-visible';
 export { KeyCode, isModifierKey } from './keycode';
-export { getGlobalFlag } from './global-flags';
+export { getGlobalFlag, setGlobalFlag } from './global-flags';


### PR DESCRIPTION
Needed for testing purposes (e.g. https://github.com/cloudscape-design/components/blob/main/src/internal/widgets/__tests__/utils.ts)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
