### PR TITLE
chore: Expose testing helpers as separate export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     ".": "./index.js",
     "./dom": "./dom/index.js",
     "./internal": "./internal/index.js",
+    "./internal/testing": "./internal/testing/index.js",
     "./internal/analytics-metadata": "./internal/analytics-metadata/index.js",
     "./internal/analytics-metadata/utils": "./internal/analytics-metadata/utils.js",
     "./package.json": "./package.json"

--- a/src/internal/base-component/metrics/metrics.ts
+++ b/src/internal/base-component/metrics/metrics.ts
@@ -101,8 +101,10 @@ export class Metrics {
   }
 }
 
+export function clearOneTimeMetricsCache(): void {
+  oneTimeMetrics.clear();
+}
+
 export class MetricsTestHelper {
-  resetOneTimeMetricsCache() {
-    oneTimeMetrics.clear();
-  }
+  resetOneTimeMetricsCache = clearOneTimeMetricsCache;
 }

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -27,4 +27,4 @@ export {
 } from './direction';
 export { useFocusVisible } from './focus-visible';
 export { KeyCode, isModifierKey } from './keycode';
-export { getGlobalFlag, setGlobalFlag } from './global-flags';
+export { getGlobalFlag } from './global-flags';

--- a/src/internal/testing.ts
+++ b/src/internal/testing.ts
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { clearOneTimeMetricsCache } from './base-component/metrics/metrics';
+export { clearMessageCache } from './logging';
+export { setGlobalFlag } from './global-flags';
+export { clearVisualRefreshState } from './visual-mode';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow for more clear separation what is imported in prod code and what is for testing.

After migration, I will clean up current main exports from test helpers


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
