### PR TITLE
chore: trim analytics labels

### DIFF
--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -93,6 +93,22 @@ describe('getLabelFromElement', () => {
     const target = container.querySelector('#target');
     expect(getLabelFromElement(target as HTMLElement)).toEqual('');
   });
+  test('trims the label', () => {
+    const { container } = render(
+      <div>
+        <div id="target1" aria-label=" abcd efg ">
+          content
+        </div>
+        <div id="target2">
+          {'   '}content{'   '}
+        </div>
+      </div>
+    );
+    const target1 = container.querySelector('#target1');
+    expect(getLabelFromElement(target1 as HTMLElement)).toEqual('abcd efg');
+    const target2 = container.querySelector('#target2');
+    expect(getLabelFromElement(target2 as HTMLElement)).toEqual('content');
+  });
 });
 
 describe('processLabel', () => {

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -56,7 +56,7 @@ export const getLabelFromElement = (element: HTMLElement | null): string => {
   }
   const ariaLabel = element.getAttribute('aria-label');
   if (ariaLabel) {
-    return ariaLabel;
+    return ariaLabel.trim();
   }
   const ariaLabelledBy = element.getAttribute('aria-labelledby');
   if (ariaLabelledBy) {
@@ -64,5 +64,5 @@ export const getLabelFromElement = (element: HTMLElement | null): string => {
     return getLabelFromElement(elementWithLabel as HTMLElement);
   }
 
-  return element.textContent || '';
+  return element.textContent ? element.textContent.trim() : '';
 };


### PR DESCRIPTION
To remove noise introduces, for example, by external icon in links


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
