### PR TITLE
chore: Add global flag for app layout toolbar

### DIFF
--- a/src/internal/global-flags/index.ts
+++ b/src/internal/global-flags/index.ts
@@ -6,6 +6,7 @@ export const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
 
 interface GlobalFlags {
   appLayoutWidget?: boolean;
+  appLayoutToolbar?: boolean;
   analyticsMetadata?: boolean;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a new feature flag, `appLayoutToolbar` to allow enabling the App Layout Toolbar design, but without the widget (like the existing `appLayoutWidget` works)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
