### PR TITLE
chore: Use setWindowSize browser-test-tools util

### DIFF
--- a/src/internal/container-queries/__integ__/use-resize-observer.test.ts
+++ b/src/internal/container-queries/__integ__/use-resize-observer.test.ts
@@ -6,7 +6,7 @@ import { BasePageObject } from '@cloudscape-design/browser-test-tools/page-objec
 
 export class PageObject extends BasePageObject {
   resizeWindow(width: number, height: number) {
-    return this.browser.setWindowSize(width, height);
+    return this.setWindowSize({ width, height });
   }
 }
 


### PR DESCRIPTION
Replacing browser.setWindowSize (WebdriverIO) with page.setWindowSize (browser-test-tools) to take advantage of the new Chrome headless mode fix (see https://github.com/cloudscape-design/browser-test-tools/pull/105).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
