### PR TITLE
feat: Allow body selector for labels roots in analytics metadata

### DIFF
--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -206,18 +206,23 @@ describe('processLabel', () => {
   });
   test('respects the root property', () => {
     const { container } = render(
-      <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })}>
-        <div className="label-class">outer label</div>
-        <div id="target">
-          <div className="label-class">inner label</div>
+      <>
+        <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })}>
+          <div className="label-class">outer label</div>
+          <div id="target">
+            <div className="label-class">inner label</div>
+          </div>
         </div>
-      </div>
+        <div className="outer-class">label outside of the component</div>
+      </>
     );
     const target = container.querySelector('#target') as HTMLElement;
     //  root="self" refers to the element containing the data attribute
     expect(processLabel(target, { selector: '.label-class', root: 'self' })).toEqual('inner label');
-    //  root="self" refers to the parent component
+    //  root="component" refers to the parent component
     expect(processLabel(target, { selector: '.label-class', root: 'component' })).toEqual('outer label');
+    //  root="body" refers to body
+    expect(processLabel(target, { selector: '.outer-class', root: 'body' })).toEqual('label outside of the component');
   });
 
   test('forwards the label resolution with data-awsui-analytics-label', () => {

--- a/src/internal/analytics-metadata/interfaces.ts
+++ b/src/internal/analytics-metadata/interfaces.ts
@@ -36,7 +36,7 @@ interface GeneratedAnalyticsMetadataComponentContext {
 
 export interface LabelIdentifier {
   selector?: string | Array<string>;
-  root?: 'component' | 'self';
+  root?: 'component' | 'self' | 'body';
 }
 
 export interface GeneratedAnalyticsMetadataFragment extends Omit<Partial<GeneratedAnalyticsMetadata>, 'detail'> {

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -40,6 +40,9 @@ const processSingleLabel = (
   if (root === 'component') {
     return processSingleLabel(findComponentUp(node), labelSelector);
   }
+  if (root === 'body') {
+    return processSingleLabel(document.body, labelSelector);
+  }
   let labelElement: HTMLElement | null = node;
   if (labelSelector) {
     labelElement = labelElement.querySelector(labelSelector) as HTMLElement | null;


### PR DESCRIPTION
Needed to identify group labels in dropdown-based components when expandToViewport=true


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
