### PR TITLE
feat: Allow to specify a root class name as a label identifier in ana…

### DIFF
--- a/src/internal/analytics-metadata/__tests__/components.tsx
+++ b/src/internal/analytics-metadata/__tests__/components.tsx
@@ -52,6 +52,7 @@ export const ComponentThree = () => (
             position: '2',
             columnLabel: { selector: '.invalid-selector', root: 'self' },
             anotherLabel: { root: 'self' },
+            yetAnotherLabel: { rootClassName: 'root-class-name' },
           },
         },
       })}

--- a/src/internal/analytics-metadata/__tests__/components.tsx
+++ b/src/internal/analytics-metadata/__tests__/components.tsx
@@ -52,7 +52,7 @@ export const ComponentThree = () => (
             position: '2',
             columnLabel: { selector: '.invalid-selector', root: 'self' },
             anotherLabel: { root: 'self' },
-            yetAnotherLabel: { rootClassName: 'root-class-name' },
+            yetAnotherLabel: { rootSelector: '.root-class-name' },
           },
         },
       })}

--- a/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
@@ -114,15 +114,14 @@ describe('findComponentUp', () => {
 });
 
 describe('findSelectorUp', () => {
-  test('returns null when the node is null and/or the className is empty', () => {
+  test('returns null when the node is null or the className is invalid', () => {
     expect(findSelectorUp(null, 'abcd')).toBeNull();
-    expect(findSelectorUp(null, '')).toBeNull();
     const { container } = render(
       <div id="root-element">
         <div id="target-element"></div>
       </div>
     );
-    expect(findSelectorUp(container.querySelector('#target-element'), '')).toBeNull();
+    expect(findSelectorUp(container.querySelector('#target-element'), '.dummy')).toBeNull();
   });
   test('returns root element', () => {
     const { container } = render(

--- a/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
@@ -130,7 +130,7 @@ describe('findByClassNameUp', () => {
         <div id="target-element"></div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), 'test-class')!.id).toBe('root-element');
+    expect(findByClassNameUp(container.querySelector('#target-element'), '.test-class')!.id).toBe('root-element');
   });
   test('returns parent component element with portals', () => {
     const { container } = render(
@@ -143,7 +143,7 @@ describe('findByClassNameUp', () => {
         </div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), 'test-class')!.id).toBe('root-element');
+    expect(findByClassNameUp(container.querySelector('#target-element'), '.test-class')!.id).toBe('root-element');
   });
   test('returns null when element has no parent element with className', () => {
     const { container } = render(
@@ -151,6 +151,6 @@ describe('findByClassNameUp', () => {
         <div id="target-element"></div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), 'test-class')).toBeNull();
+    expect(findByClassNameUp(container.querySelector('#target-element'), '.test-class')).toBeNull();
   });
 });

--- a/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { activateAnalyticsMetadata, getAnalyticsMetadataAttribute, METADATA_ATTRIBUTE } from '../attributes';
-import { findLogicalParent, isNodeComponent, findComponentUp } from '../dom-utils';
+import { findLogicalParent, isNodeComponent, findComponentUp, findByClassNameUp } from '../dom-utils';
 
 beforeAll(() => {
   activateAnalyticsMetadata(true);
@@ -18,7 +18,7 @@ describe('findLogicalParent', () => {
       </div>
     );
     const child = container.querySelector('#child');
-    expect(findLogicalParent(child as HTMLElement)?.id).toEqual('parent');
+    expect(findLogicalParent(child as HTMLElement)!.id).toEqual('parent');
   });
   test('returns null when child does not exist', () => {
     const { container } = render(
@@ -88,7 +88,7 @@ describe('findComponentUp', () => {
         <div id="target-element"></div>
       </div>
     );
-    expect(findComponentUp(container.querySelector('#target-element'))?.id).toBe('component-element');
+    expect(findComponentUp(container.querySelector('#target-element'))!.id).toBe('component-element');
   });
   test('returns parent component element with portals', () => {
     const { container } = render(
@@ -101,7 +101,7 @@ describe('findComponentUp', () => {
         </div>
       </div>
     );
-    expect(findComponentUp(container.querySelector('#target-element'))?.id).toBe('component-element');
+    expect(findComponentUp(container.querySelector('#target-element'))!.id).toBe('component-element');
   });
   test('returns null when element has no parent component', () => {
     const { container } = render(
@@ -110,5 +110,47 @@ describe('findComponentUp', () => {
       </div>
     );
     expect(findComponentUp(container.querySelector('#target-element'))).toBeNull();
+  });
+});
+
+describe('findByClassNameUp', () => {
+  test('returns null when the node is null and/or the className is empty', () => {
+    expect(findByClassNameUp(null, 'abcd')).toBeNull();
+    expect(findByClassNameUp(null, '')).toBeNull();
+    const { container } = render(
+      <div id="root-element">
+        <div id="target-element"></div>
+      </div>
+    );
+    expect(findByClassNameUp(container.querySelector('#target-element'), '')).toBeNull();
+  });
+  test('returns root element', () => {
+    const { container } = render(
+      <div id="root-element" className="test-class">
+        <div id="target-element"></div>
+      </div>
+    );
+    expect(findByClassNameUp(container.querySelector('#target-element'), 'test-class')!.id).toBe('root-element');
+  });
+  test('returns parent component element with portals', () => {
+    const { container } = render(
+      <div>
+        <div id="root-element" className="test-class">
+          <div id=":rr5:"></div>
+        </div>
+        <div data-awsui-referrer-id=":rr5:">
+          <div id="target-element"></div>
+        </div>
+      </div>
+    );
+    expect(findByClassNameUp(container.querySelector('#target-element'), 'test-class')!.id).toBe('root-element');
+  });
+  test('returns null when element has no parent element with className', () => {
+    const { container } = render(
+      <div>
+        <div id="target-element"></div>
+      </div>
+    );
+    expect(findByClassNameUp(container.querySelector('#target-element'), 'test-class')).toBeNull();
   });
 });

--- a/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/dom-utils.test.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { activateAnalyticsMetadata, getAnalyticsMetadataAttribute, METADATA_ATTRIBUTE } from '../attributes';
-import { findLogicalParent, isNodeComponent, findComponentUp, findByClassNameUp } from '../dom-utils';
+import { findLogicalParent, isNodeComponent, findComponentUp, findSelectorUp } from '../dom-utils';
 
 beforeAll(() => {
   activateAnalyticsMetadata(true);
@@ -113,16 +113,16 @@ describe('findComponentUp', () => {
   });
 });
 
-describe('findByClassNameUp', () => {
+describe('findSelectorUp', () => {
   test('returns null when the node is null and/or the className is empty', () => {
-    expect(findByClassNameUp(null, 'abcd')).toBeNull();
-    expect(findByClassNameUp(null, '')).toBeNull();
+    expect(findSelectorUp(null, 'abcd')).toBeNull();
+    expect(findSelectorUp(null, '')).toBeNull();
     const { container } = render(
       <div id="root-element">
         <div id="target-element"></div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), '')).toBeNull();
+    expect(findSelectorUp(container.querySelector('#target-element'), '')).toBeNull();
   });
   test('returns root element', () => {
     const { container } = render(
@@ -130,7 +130,7 @@ describe('findByClassNameUp', () => {
         <div id="target-element"></div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), '.test-class')!.id).toBe('root-element');
+    expect(findSelectorUp(container.querySelector('#target-element'), '.test-class')!.id).toBe('root-element');
   });
   test('returns parent component element with portals', () => {
     const { container } = render(
@@ -143,7 +143,7 @@ describe('findByClassNameUp', () => {
         </div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), '.test-class')!.id).toBe('root-element');
+    expect(findSelectorUp(container.querySelector('#target-element'), '.test-class')!.id).toBe('root-element');
   });
   test('returns null when element has no parent element with className', () => {
     const { container } = render(
@@ -151,6 +151,6 @@ describe('findByClassNameUp', () => {
         <div id="target-element"></div>
       </div>
     );
-    expect(findByClassNameUp(container.querySelector('#target-element'), '.test-class')).toBeNull();
+    expect(findSelectorUp(container.querySelector('#target-element'), '.test-class')).toBeNull();
   });
 });

--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -225,7 +225,7 @@ describe('processLabel', () => {
     expect(processLabel(target, { selector: '.outer-class', root: 'body' })).toEqual('label outside of the component');
   });
 
-  test('respects the rootClassName property', () => {
+  test('respects the rootSelector property', () => {
     const { container } = render(
       <div className="root-class">
         <div className="label-class">outer label</div>
@@ -235,9 +235,9 @@ describe('processLabel', () => {
       </div>
     );
     const target = container.querySelector('#target') as HTMLElement;
-    expect(processLabel(target, { selector: '.label-class', rootClassName: 'root-class' })).toEqual('outer label');
+    expect(processLabel(target, { selector: '.label-class', rootSelector: '.root-class' })).toEqual('outer label');
   });
-  test('rootClassName prevails over root property', () => {
+  test('rootSelector prevails over root property', () => {
     const { container } = render(
       <>
         <div className="root-class">
@@ -253,13 +253,13 @@ describe('processLabel', () => {
       </>
     );
     const target = container.querySelector('#target') as HTMLElement;
-    expect(processLabel(target, { selector: '.label-class', root: 'self', rootClassName: 'root-class' })).toEqual(
+    expect(processLabel(target, { selector: '.label-class', root: 'self', rootSelector: '.root-class' })).toEqual(
       'root class label'
     );
-    expect(processLabel(target, { selector: '.label-class', root: 'component', rootClassName: 'root-class' })).toEqual(
+    expect(processLabel(target, { selector: '.label-class', root: 'component', rootSelector: '.root-class' })).toEqual(
       'root class label'
     );
-    expect(processLabel(target, { selector: '.outer-class', root: 'body', rootClassName: 'root-class' })).toEqual('');
+    expect(processLabel(target, { selector: '.outer-class', root: 'body', rootSelector: '.root-class' })).toEqual('');
   });
 
   test('forwards the label resolution with data-awsui-analytics-label', () => {

--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -225,6 +225,43 @@ describe('processLabel', () => {
     expect(processLabel(target, { selector: '.outer-class', root: 'body' })).toEqual('label outside of the component');
   });
 
+  test('respects the rootClassName property', () => {
+    const { container } = render(
+      <div className="root-class">
+        <div className="label-class">outer label</div>
+        <div id="target">
+          <div className="label-class">inner label</div>
+        </div>
+      </div>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(processLabel(target, { selector: '.label-class', rootClassName: 'root-class' })).toEqual('outer label');
+  });
+  test('rootClassName prevails over root property', () => {
+    const { container } = render(
+      <>
+        <div className="root-class">
+          <div className="label-class">root class label</div>
+          <div {...getAnalyticsMetadataAttribute({ component: { name: 'ComponentName' } })}>
+            <div className="label-class">component label</div>
+            <div id="target">
+              <div className="label-class">inner label</div>
+            </div>
+          </div>
+        </div>
+        <div className="outer-class">label outside of the component</div>
+      </>
+    );
+    const target = container.querySelector('#target') as HTMLElement;
+    expect(processLabel(target, { selector: '.label-class', root: 'self', rootClassName: 'root-class' })).toEqual(
+      'root class label'
+    );
+    expect(processLabel(target, { selector: '.label-class', root: 'component', rootClassName: 'root-class' })).toEqual(
+      'root class label'
+    );
+    expect(processLabel(target, { selector: '.outer-class', root: 'body', rootClassName: 'root-class' })).toEqual('');
+  });
+
   test('forwards the label resolution with data-awsui-analytics-label', () => {
     const { container } = render(
       <div>

--- a/src/internal/analytics-metadata/__tests__/testing-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/testing-utils.test.tsx
@@ -60,7 +60,7 @@ describe('getRawAnalyticsMetadata', () => {
                 root: 'self',
               },
               yetAnotherLabel: {
-                rootClassName: 'root-class-name',
+                rootSelector: '.root-class-name',
               },
             },
           },

--- a/src/internal/analytics-metadata/__tests__/testing-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/testing-utils.test.tsx
@@ -59,6 +59,9 @@ describe('getRawAnalyticsMetadata', () => {
               anotherLabel: {
                 root: 'self',
               },
+              yetAnotherLabel: {
+                rootClassName: 'root-class-name',
+              },
             },
           },
         },
@@ -74,6 +77,7 @@ describe('getRawAnalyticsMetadata', () => {
         '.component-label',
         '.component-label',
         '.invalid-selector',
+        '.root-class-name',
       ],
     });
   });

--- a/src/internal/analytics-metadata/__tests__/utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/utils.test.tsx
@@ -70,6 +70,7 @@ describe('getGeneratedAnalyticsMetadata', () => {
                 position: '2',
                 columnLabel: '',
                 anotherLabel: 'sub labelanother text content to ignorecontentcomponent labelevent label',
+                yetAnotherLabel: '',
               },
             },
           },

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -36,12 +36,12 @@ export const isNodeComponent = (node: HTMLElement): boolean => {
   }
 };
 
-export function findByClassNameUp(node: HTMLElement | null, className: string): HTMLElement | null {
-  if (!node || !className) {
+export function findByClassNameUp(node: HTMLElement | null, selector: string): HTMLElement | null {
+  if (!selector) {
     return null;
   }
   let current: HTMLElement | null = node;
-  while (current && current.tagName !== 'body' && !current.classList.contains(className)) {
+  while (current && current.tagName !== 'body' && !current.matches(selector)) {
     current = findLogicalParent(current);
   }
   return current && current.tagName !== 'body' ? current : null;

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -35,3 +35,14 @@ export const isNodeComponent = (node: HTMLElement): boolean => {
     return false;
   }
 };
+
+export function findByClassNameUp(node: HTMLElement | null, className: string): HTMLElement | null {
+  if (!node || !className) {
+    return null;
+  }
+  let current: HTMLElement | null = node;
+  while (current && current.tagName !== 'body' && !current.classList.contains(className)) {
+    current = findLogicalParent(current);
+  }
+  return current && current.tagName !== 'body' ? current : null;
+}

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -36,7 +36,7 @@ export const isNodeComponent = (node: HTMLElement): boolean => {
   }
 };
 
-export function findByClassNameUp(node: HTMLElement | null, selector: string): HTMLElement | null {
+export function findSelectorUp(node: HTMLElement | null, selector: string): HTMLElement | null {
   if (!selector) {
     return null;
   }

--- a/src/internal/analytics-metadata/dom-utils.ts
+++ b/src/internal/analytics-metadata/dom-utils.ts
@@ -37,9 +37,6 @@ export const isNodeComponent = (node: HTMLElement): boolean => {
 };
 
 export function findSelectorUp(node: HTMLElement | null, selector: string): HTMLElement | null {
-  if (!selector) {
-    return null;
-  }
   let current: HTMLElement | null = node;
   while (current && current.tagName !== 'body' && !current.matches(selector)) {
     current = findLogicalParent(current);

--- a/src/internal/analytics-metadata/interfaces.ts
+++ b/src/internal/analytics-metadata/interfaces.ts
@@ -37,7 +37,7 @@ interface GeneratedAnalyticsMetadataComponentContext {
 export interface LabelIdentifier {
   selector?: string | Array<string>;
   root?: 'component' | 'self' | 'body';
-  rootClassName?: string;
+  rootSelector?: string;
 }
 
 export interface GeneratedAnalyticsMetadataFragment extends Omit<Partial<GeneratedAnalyticsMetadata>, 'detail'> {

--- a/src/internal/analytics-metadata/interfaces.ts
+++ b/src/internal/analytics-metadata/interfaces.ts
@@ -37,6 +37,7 @@ interface GeneratedAnalyticsMetadataComponentContext {
 export interface LabelIdentifier {
   selector?: string | Array<string>;
   root?: 'component' | 'self' | 'body';
+  rootClassName?: string;
 }
 
 export interface GeneratedAnalyticsMetadataFragment extends Omit<Partial<GeneratedAnalyticsMetadata>, 'detail'> {

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LABEL_DATA_ATTRIBUTE } from './attributes';
-import { findComponentUp } from './dom-utils';
+import { findByClassNameUp, findComponentUp } from './dom-utils';
 import { LabelIdentifier } from './interfaces';
 
 export const processLabel = (node: HTMLElement | null, labelIdentifier: string | LabelIdentifier | null): string => {
@@ -13,13 +13,23 @@ export const processLabel = (node: HTMLElement | null, labelIdentifier: string |
   const selector = formattedLabelIdentifier.selector;
   if (Array.isArray(selector)) {
     for (const labelSelector of selector) {
-      const label = processSingleLabel(node, labelSelector, formattedLabelIdentifier.root);
+      const label = processSingleLabel(
+        node,
+        labelSelector,
+        formattedLabelIdentifier.root,
+        formattedLabelIdentifier.rootClassName
+      );
       if (label) {
         return label;
       }
     }
   }
-  return processSingleLabel(node, selector as string, formattedLabelIdentifier.root);
+  return processSingleLabel(
+    node,
+    selector as string,
+    formattedLabelIdentifier.root,
+    formattedLabelIdentifier.rootClassName
+  );
 };
 
 const formatLabelIdentifier = (labelIdentifier: string | LabelIdentifier): LabelIdentifier => {
@@ -32,10 +42,14 @@ const formatLabelIdentifier = (labelIdentifier: string | LabelIdentifier): Label
 const processSingleLabel = (
   node: HTMLElement | null,
   labelSelector: string,
-  root: LabelIdentifier['root'] = 'self'
+  root: LabelIdentifier['root'] = 'self',
+  rootClassName?: string
 ): string => {
   if (!node) {
     return '';
+  }
+  if (rootClassName) {
+    return processSingleLabel(findByClassNameUp(node, rootClassName), labelSelector);
   }
   if (root === 'component') {
     return processSingleLabel(findComponentUp(node), labelSelector);

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LABEL_DATA_ATTRIBUTE } from './attributes';
-import { findByClassNameUp, findComponentUp } from './dom-utils';
+import { findSelectorUp, findComponentUp } from './dom-utils';
 import { LabelIdentifier } from './interfaces';
 
 export const processLabel = (node: HTMLElement | null, labelIdentifier: string | LabelIdentifier | null): string => {
@@ -49,7 +49,7 @@ const processSingleLabel = (
     return '';
   }
   if (rootSelector) {
-    return processSingleLabel(findByClassNameUp(node, rootSelector), labelSelector);
+    return processSingleLabel(findSelectorUp(node, rootSelector), labelSelector);
   }
   if (root === 'component') {
     return processSingleLabel(findComponentUp(node), labelSelector);

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -17,7 +17,7 @@ export const processLabel = (node: HTMLElement | null, labelIdentifier: string |
         node,
         labelSelector,
         formattedLabelIdentifier.root,
-        formattedLabelIdentifier.rootClassName
+        formattedLabelIdentifier.rootSelector
       );
       if (label) {
         return label;
@@ -28,7 +28,7 @@ export const processLabel = (node: HTMLElement | null, labelIdentifier: string |
     node,
     selector as string,
     formattedLabelIdentifier.root,
-    formattedLabelIdentifier.rootClassName
+    formattedLabelIdentifier.rootSelector
   );
 };
 
@@ -43,13 +43,13 @@ const processSingleLabel = (
   node: HTMLElement | null,
   labelSelector: string,
   root: LabelIdentifier['root'] = 'self',
-  rootClassName?: string
+  rootSelector?: string
 ): string => {
   if (!node) {
     return '';
   }
-  if (rootClassName) {
-    return processSingleLabel(findByClassNameUp(node, rootClassName), labelSelector);
+  if (rootSelector) {
+    return processSingleLabel(findByClassNameUp(node, rootSelector), labelSelector);
   }
   if (root === 'component') {
     return processSingleLabel(findComponentUp(node), labelSelector);

--- a/src/internal/analytics-metadata/testing-utils.ts
+++ b/src/internal/analytics-metadata/testing-utils.ts
@@ -44,13 +44,20 @@ const getLabelSelectors = (localMetadata: any): Array<string> => {
 };
 
 const getLabelSelectorsFromLabelIdentifier = (label: string | LabelIdentifier): Array<string> => {
+  let labels: Array<string> = [];
   if (typeof label === 'string') {
-    return [label];
-  } else if (label.selector) {
-    if (typeof label.selector === 'string') {
-      return [label.selector];
+    labels.push(label);
+  } else {
+    if (label.selector) {
+      if (typeof label.selector === 'string') {
+        labels.push(label.selector);
+      } else {
+        labels = [...label.selector];
+      }
     }
-    return label.selector;
+    if (label.rootClassName) {
+      labels.push(`.${label.rootClassName}`);
+    }
   }
-  return [];
+  return labels;
 };

--- a/src/internal/analytics-metadata/testing-utils.ts
+++ b/src/internal/analytics-metadata/testing-utils.ts
@@ -55,8 +55,8 @@ const getLabelSelectorsFromLabelIdentifier = (label: string | LabelIdentifier): 
         labels = [...label.selector];
       }
     }
-    if (label.rootClassName) {
-      labels.push(`.${label.rootClassName}`);
+    if (label.rootSelector) {
+      labels.push(label.rootSelector);
     }
   }
   return labels;


### PR DESCRIPTION
…lytics metadata

We currently use  `root="component"` in Expandable section (https://github.com/cloudscape-design/components/blob/main/src/expandable-section/expandable-section-header.tsx#L68) to identify the label of the section.

This approach does not work when using the internal version of the component, because `root="component"`refers to the component that is using the internal version. For example, Side navigation.

This new approach allows to specify a root class name that becomes independent of whether the 'component' boundaries are set.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
