### PR TITLE
chore: Use ownerDocument.defaultView for isMotionDisabled

### DIFF
--- a/src/internal/visual-mode/__tests__/motion.test.tsx
+++ b/src/internal/visual-mode/__tests__/motion.test.tsx
@@ -69,4 +69,21 @@ describe('isMotionDisabled', () => {
     const element = renderResult.container.querySelector('#test-element') as HTMLElement;
     expect(isMotionDisabled(element)).toEqual(true);
   });
+
+  test('should default to false when an error is thrown and a warning is logged', () => {
+    matchMedia.mockReturnValue(null);
+
+    const warnSpy = jest.spyOn(console, 'warn');
+
+    const renderResult = render(
+      <div>
+        <div id="test-element">Content</div>
+      </div>
+    );
+    const element = renderResult.container.querySelector('#test-element') as HTMLElement;
+
+    expect(isMotionDisabled(element)).toEqual(false);
+
+    expect(warnSpy).toHaveBeenCalled();
+  });
 });

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -10,10 +10,17 @@ import { warnOnce } from '../logging';
 import { awsuiVisualRefreshFlag, getGlobal } from '../global-flags';
 
 export function isMotionDisabled(element: HTMLElement): boolean {
-  return (
-    !!findUpUntil(element, node => node.classList.contains('awsui-motion-disabled')) ||
-    (element?.ownerDocument?.defaultView?.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false)
-  );
+  try {
+    const targetWindow = element.ownerDocument?.defaultView ?? window;
+
+    return (
+      !!findUpUntil(element, node => node.classList.contains('awsui-motion-disabled')) ||
+      (targetWindow?.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false)
+    );
+  } catch (error) {
+    console.warn(error);
+    return false;
+  }
 }
 
 // Note that this hook doesn't take into consideration @media print (unlike the dark mode CSS),

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -12,7 +12,7 @@ import { awsuiVisualRefreshFlag, getGlobal } from '../global-flags';
 export function isMotionDisabled(element: HTMLElement): boolean {
   return (
     !!findUpUntil(element, node => node.classList.contains('awsui-motion-disabled')) ||
-    (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches ?? false)
+    (element?.ownerDocument?.defaultView?.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false)
   );
 }
 

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -9,18 +9,21 @@ import { isDevelopment } from '../is-development';
 import { warnOnce } from '../logging';
 import { awsuiVisualRefreshFlag, getGlobal } from '../global-flags';
 
-export function isMotionDisabled(element: HTMLElement): boolean {
+function safeMatchMedia(element: HTMLElement, query: string) {
   try {
     const targetWindow = element.ownerDocument?.defaultView ?? window;
-
-    return (
-      !!findUpUntil(element, node => node.classList.contains('awsui-motion-disabled')) ||
-      (targetWindow?.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false)
-    );
+    return targetWindow.matchMedia(query).matches ?? false;
   } catch (error) {
     console.warn(error);
     return false;
   }
+}
+
+export function isMotionDisabled(element: HTMLElement): boolean {
+  return (
+    !!findUpUntil(element, node => node.classList.contains('awsui-motion-disabled')) ||
+    safeMatchMedia(element, '(prefers-reduced-motion: reduce)')
+  );
 }
 
 // Note that this hook doesn't take into consideration @media print (unlike the dark mode CSS),

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -12,7 +12,7 @@ import { awsuiVisualRefreshFlag, getGlobal } from '../global-flags';
 function safeMatchMedia(element: HTMLElement, query: string) {
   try {
     const targetWindow = element.ownerDocument?.defaultView ?? window;
-    return targetWindow.matchMedia(query).matches ?? false;
+    return targetWindow.matchMedia?.(query).matches ?? false;
   } catch (error) {
     console.warn(error);
     return false;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In some rare cases, `window.mediaMatch` returns null, to support the usage of iframes this PR replaces `window` with `element.ownerDocument.defaultView`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
