### PR TITLE
fix: FIx react act warnings

### DIFF
--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -56,7 +56,18 @@ export function useDensityMode(elementRef: React.RefObject<HTMLElement>) {
 export function useReducedMotion(elementRef: React.RefObject<HTMLElement>) {
   const [value, setValue] = useState(false);
   useMutationObserver(elementRef, node => {
-    setValue(isMotionDisabled(node));
+    const newValue = isMotionDisabled(node);
+    /**
+     * React has a behavior that triggers a re-render even if the same value is provided in the setState, while it does not
+     * commit any changes to the DOM (commit phase) the function rerenders. This causes a false react act warnings in testing
+     * and any component using the Transition component which in return uses this hook will possibly have false react warnings.
+     *
+     * To fix this, we manually stop setting the state ourselves if we see the same value.
+     * References:  https://www.reddit.com/r/reactjs/comments/1ej505e/why_does_it_rerender_even_when_state_is_same/#:~:text=If%20the%20new%20value%20you,shouldn't%20affect%20your%20code
+     */
+    if (newValue !== value) {
+      setValue(isMotionDisabled(node));
+    }
   });
   return value;
 }

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -66,7 +66,7 @@ export function useReducedMotion(elementRef: React.RefObject<HTMLElement>) {
      * References:  https://www.reddit.com/r/reactjs/comments/1ej505e/why_does_it_rerender_even_when_state_is_same/#:~:text=If%20the%20new%20value%20you,shouldn't%20affect%20your%20code
      */
     if (newValue !== value) {
-      setValue(isMotionDisabled(node));
+      setValue(newValue);
     }
   });
   return value;


### PR DESCRIPTION
When using test utils in some of our components we get react act warnings, an example of a utility that does that is inside the Autosuggest wrapper `wrapper.findAutosuggest().openDrawer()`.

This happens in all of the components that changes a state like opening a drawer, closing a drawer, or doing an action that will create a transitition effect. The logs of that act warnings:

```
console.error                                                                                          
    Warning: An update to Transition inside a test was not wrapped in act(...).                          
                                                                                                         
    When testing, code that causes React state updates should be wrapped into act(...):                  
                                                                                                         
    act(() => {                                                                                          
      /* fire events that update state */                                                                
    });                                                                                                  
    /* assert on the output */                                                                           
                                                                                                         
```

When looking closely, we can notice that the warning is emitted from the setValue state inside the `useReducedMotion` effect, this is because React does a re-render phase even if the value is the same which is an unexpected behavior. 

So for example, if the initial value of the hook is false, and the mutation observer triggered another callback with another value of false, React will reredner the component using that hook, which is the Transition component. 

Any following set states with the same value will cause no rerenders in React, this behavior is disccused in great detail in this thread:
https://www.reddit.com/r/reactjs/comments/1ej505e/comment/lths0uh/

To have a resolution, we can manually not update any state if the previous value and the current value is equal inside the hook, this will by defailt fix all of the act warnings stemming from the Transition component.

The solution here might not be ideal, but this is an internal behavior. Following up, I will create an issue with a reproduicble example to the React team and link it here for future work (if needed).


