### PR TITLE
chore: Apply act warning fix to all hooks that uses useMutationObserver

### DIFF
--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -36,7 +36,12 @@ export function useCurrentMode(elementRef: React.RefObject<HTMLElement>) {
       node,
       node => node.classList.contains('awsui-polaris-dark-mode') || node.classList.contains('awsui-dark-mode')
     );
-    setValue(darkModeParent ? 'dark' : 'light');
+    const newValue = darkModeParent ? 'dark' : 'light';
+
+    // refer to the comment below in `useReducedMotion`
+    if (newValue !== value) {
+      setValue(darkModeParent ? 'dark' : 'light');
+    }
   });
   return value;
 }
@@ -48,7 +53,12 @@ export function useDensityMode(elementRef: React.RefObject<HTMLElement>) {
       node,
       node => node.classList.contains('awsui-polaris-compact-mode') || node.classList.contains('awsui-compact-mode')
     );
-    setValue(compactModeParent ? 'compact' : 'comfortable');
+    const newValue = compactModeParent ? 'compact' : 'comfortable';
+
+    // refer to the comment below in `useReducedMotion`
+    if (newValue !== value) {
+      setValue(compactModeParent ? 'compact' : 'comfortable');
+    }
   });
   return value;
 }

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -40,7 +40,7 @@ export function useCurrentMode(elementRef: React.RefObject<HTMLElement>) {
 
     // refer to the comment below in `useReducedMotion`
     if (newValue !== value) {
-      setValue(darkModeParent ? 'dark' : 'light');
+      setValue(newValue);
     }
   });
   return value;
@@ -57,7 +57,7 @@ export function useDensityMode(elementRef: React.RefObject<HTMLElement>) {
 
     // refer to the comment below in `useReducedMotion`
     if (newValue !== value) {
-      setValue(compactModeParent ? 'compact' : 'comfortable');
+      setValue(newValue);
     }
   });
   return value;


### PR DESCRIPTION
*Issue #, if available:*

follows up a fix in this PR: https://github.com/cloudscape-design/component-toolkit/commit/2b188cf55e96fd01060f28916005c386ad09008c

it turns out that all usages that uses the `useMutationObserver` requires this fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
