### PR TITLE
fix: Correctly merge empty strings in analytics metadata

### DIFF
--- a/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
+++ b/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
@@ -40,9 +40,9 @@ describe('merge', () => {
     expect(merge(target, source)).toEqual(source);
   });
   test('recursively merges keys when not defined in nested target', () => {
-    const source = { one: { two: 'two' } };
+    const source = { one: { two: 'two', four: '' } };
     const target = { one: { three: 'three' } };
-    expect(merge(target, source)).toEqual({ one: { two: 'two', three: 'three' } });
+    expect(merge(target, source)).toEqual({ one: { two: 'two', three: 'three', four: '' } });
   });
   test('copies arrays in target', () => {
     const source = { two: 'two' };

--- a/src/internal/analytics-metadata/metadata-utils.ts
+++ b/src/internal/analytics-metadata/metadata-utils.ts
@@ -29,6 +29,10 @@ export const processMetadata = (node: HTMLElement | null, localMetadata: any): G
   }, {});
 };
 
+const isNil = (value: any) => {
+  return typeof value === 'undefined' || value === null;
+};
+
 export const merge = (inputTarget: any, inputSource: any): any => {
   const merged: any = {};
   const target = inputTarget || {};
@@ -39,7 +43,7 @@ export const merge = (inputTarget: any, inputSource: any): any => {
   for (const key of allKeys) {
     if (target[key] && !source[key]) {
       merged[key] = target[key];
-    } else if (!target[key] && source[key]) {
+    } else if (!target[key] && !isNil(source[key])) {
       merged[key] = source[key];
     } else if (typeof target[key] === 'string') {
       merged[key] = source[key];


### PR DESCRIPTION
*Issue #, if available:* AWSUI-59898

*Description of changes:*
Currently, if a property in source object contains an empty string, merging logic incorrectly changes it to an empty object. 

That happens, for example, in a table without header. I'll add a test to components package for this specific use-case


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
