### PR TITLE
chore: Expose metrics as separate file export

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     ".": "./index.js",
     "./dom": "./dom/index.js",
     "./internal": "./internal/index.js",
+    "./internal/metrics": "./internal/metrics.js",
     "./internal/testing": "./internal/testing.js",
     "./internal/analytics-metadata": "./internal/analytics-metadata/index.js",
     "./internal/analytics-metadata/utils": "./internal/analytics-metadata/utils.js",

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -4,8 +4,8 @@
 export { useComponentMetadata, COMPONENT_METADATA_KEY } from './base-component/component-metadata';
 export { useComponentMetrics, ComponentConfiguration } from './base-component/component-metrics';
 export { initAwsUiVersions } from './base-component/init-awsui-versions';
-export { Metrics } from './base-component/metrics/metrics';
 export { useResizeObserver } from './container-queries/use-resize-observer';
+export { Metrics } from './metrics';
 export { createSingletonHandler, createSingletonState, UseSingleton } from './singleton-handler';
 export { useStableCallback } from './stable-callback';
 export {

--- a/src/internal/metrics.ts
+++ b/src/internal/metrics.ts
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { Metrics } from './base-component/metrics/metrics';


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reduce loaded size when importing metrics

```js
import { Metrics } from '@cloudscape-design/component-toolkit/internal'; // 3.8 Kb
import { Metrics } from '@cloudscape-design/component-toolkit/internal/metrics'; // 0.7 Kb
```

Why is this happening – `@cloudscape-design/component-toolkit/internal` also loads ResizeObserver polyfill which is a side effect, but side effects do not tree shake

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
