### PR TITLE
chore: Mark package as side effects free

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "./internal/analytics-metadata/utils": "./internal/analytics-metadata/utils.js",
     "./package.json": "./package.json"
   },
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/cloudscape-design/component-toolkit.git"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By default, bundlers are conservative and consider `Symbol.for(...)` call as a side effect and leave it in the bundle even if unused:

https://github.com/cloudscape-design/component-toolkit/blob/d5f68a152bf6f5f4226bc983d2c7d341600f5e0e/src/internal/global-flags/index.ts#L4C39-L4C78

Let's help them with a declaration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
