### PR TITLE
chore: Remove componentsLoaded metric

### DIFF
--- a/src/internal/base-component/__tests__/metrics.test.ts
+++ b/src/internal/base-component/__tests__/metrics.test.ts
@@ -416,21 +416,6 @@ describe('Client Metrics support', () => {
     });
   });
 
-  describe('logComponentsLoaded', () => {
-    test('logs the components package loaded metric', () => {
-      metrics.logComponentsLoaded();
-      checkMetric(`awsui_dummy-package_d10`, {
-        o: 'main',
-        s: 'dummy-package',
-        t: 'default',
-        a: 'loaded',
-        f: 'react',
-        v: '1.0',
-        c: undefined,
-      });
-    });
-  });
-
   describe('sendPanoramaMetric', () => {
     test('does nothing when panorama is undefined', () => {
       delete window.panorama;

--- a/src/internal/base-component/__tests__/use-component-metrics.test.tsx
+++ b/src/internal/base-component/__tests__/use-component-metrics.test.tsx
@@ -77,7 +77,6 @@ describe('useComponentMetrics', () => {
     // the order is defined in the telemetry hook
     expect(window.AWSC.Clog.log).toHaveBeenNthCalledWith(1, 'awsui-viewport-width', 1024, undefined);
     expect(window.AWSC.Clog.log).toHaveBeenNthCalledWith(2, 'awsui-viewport-height', 768, undefined);
-    expect(window.AWSC.Clog.log).toHaveBeenNthCalledWith(3, 'awsui_toolkit_t30', 1, expect.stringContaining('loaded'));
     expect(window.AWSC.Clog.log).toHaveBeenLastCalledWith(
       getExpectedMetricName('test-component-1'),
       1,

--- a/src/internal/base-component/component-metrics.ts
+++ b/src/internal/base-component/component-metrics.ts
@@ -20,7 +20,6 @@ export function useComponentMetrics(
       metrics.sendMetricOnce('awsui-viewport-width', window.innerWidth || 0);
       metrics.sendMetricOnce('awsui-viewport-height', window.innerHeight || 0);
     }
-    metrics.logComponentsLoaded();
     metrics.logComponentUsed(componentName.toLowerCase(), configuration);
     // Components do not change the name dynamically. Explicit empty array to prevent accidental double metrics
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/internal/base-component/metrics/metrics.ts
+++ b/src/internal/base-component/metrics/metrics.ts
@@ -76,15 +76,6 @@ export class Metrics {
 
   /*
    * Reports a metric value 1 to Console Platform's client logging service to indicate that the
-   * component was loaded. The component load event will only be reported as used to client logging
-   * service once per page view.
-   */
-  logComponentsLoaded() {
-    this.sendMetricObjectOnce({ source: this.source, action: 'loaded', version: this.packageVersion }, 1);
-  }
-
-  /*
-   * Reports a metric value 1 to Console Platform's client logging service to indicate that the
    * component was used in the page.  A component will only be reported as used to client logging
    * service once per page view.
    */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This metric is redundant, because it is basically a duplicate of `logComponentUsed` call, containing the very same data.

But this metric causes us issue on the receiver's end, because it produces "fake components" in the adoption metrics, which requires workarounds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
