### PR TITLE
chore: Improve metrics format

### DIFF
--- a/src/internal/base-component/__tests__/metrics.test.ts
+++ b/src/internal/base-component/__tests__/metrics.test.ts
@@ -28,7 +28,8 @@ describe('Client Metrics support', () => {
 
   const checkMetric = (metricName: string, detailObject: MetricDetail) => {
     expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-      eventName: metricName,
+      eventType: 'awsui',
+      eventContext: metricName,
       eventDetail: JSON.stringify(detailObject),
       eventValue: '1',
       timestamp: expect.any(Number),
@@ -97,7 +98,8 @@ describe('Client Metrics support', () => {
 
         metrics.sendMetric('name', 0, undefined);
         expect(window.parent.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-          eventName: 'name',
+          eventType: 'awsui',
+          eventContext: 'name',
           eventValue: '0',
           timestamp: expect.any(Number),
         });
@@ -110,7 +112,8 @@ describe('Client Metrics support', () => {
       test('delegates to window.panorama when defined', () => {
         metrics.sendMetric('name', 0, undefined);
         expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-          eventName: 'name',
+          eventType: 'awsui',
+          eventContext: 'name',
           eventValue: '0',
           timestamp: expect.any(Number),
         });
@@ -121,7 +124,8 @@ describe('Client Metrics support', () => {
           test(`calls window.panorama when valid metric name used (${metricName})`, () => {
             metrics.sendMetric(metricName, 1, 'detail');
             expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-              eventName: metricName,
+              eventType: 'awsui',
+              eventContext: metricName,
               eventValue: '1',
               eventDetail: 'detail',
               timestamp: expect.any(Number),
@@ -163,7 +167,8 @@ describe('Client Metrics support', () => {
           const validDetail = 'a'.repeat(4000);
           metrics.sendMetric('metricName', 1, validDetail);
           expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-            eventName: 'metricName',
+            eventType: 'awsui',
+            eventContext: 'metricName',
             eventValue: '1',
             eventDetail: validDetail,
             timestamp: expect.any(Number),
@@ -186,7 +191,8 @@ describe('Client Metrics support', () => {
     test('logs a metric name only once', () => {
       metrics.sendMetricOnce('my-event', 1);
       expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-        eventName: 'my-event',
+        eventType: 'awsui',
+        eventContext: 'my-event',
         eventValue: '1',
         timestamp: expect.any(Number),
       });
@@ -200,12 +206,14 @@ describe('Client Metrics support', () => {
       metrics.sendMetricOnce('my-event', 1);
       metrics.sendMetricOnce('My-Event', 2);
       expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-        eventName: 'my-event',
+        eventType: 'awsui',
+        eventContext: 'my-event',
         eventValue: '1',
         timestamp: expect.any(Number),
       });
       expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-        eventName: 'My-Event',
+        eventType: 'awsui',
+        eventContext: 'My-Event',
         eventValue: '2',
         timestamp: expect.any(Number),
       });
@@ -218,8 +226,9 @@ describe('Client Metrics support', () => {
       window.AWSC = undefined;
       metrics.sendMetricObject({ source: 'pkg', action: 'used', version: '5.0' }, 1);
       expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
+        eventType: 'awsui',
+        eventContext: 'awsui_pkg_d50',
         eventDetail: '{"o":"main","s":"pkg","t":"default","a":"used","f":"react","v":"5.0"}',
-        eventName: 'awsui_pkg_d50',
         eventValue: '1',
         timestamp: expect.any(Number),
       });

--- a/src/internal/base-component/__tests__/panorama-metrics.test.ts
+++ b/src/internal/base-component/__tests__/panorama-metrics.test.ts
@@ -23,59 +23,35 @@ describe('PanoramaClient', () => {
   });
 
   test('sends simple metrics', () => {
-    panorama.sendMetric({ eventType: 'custom', eventValue: 'value' });
+    panorama.sendMetric({ eventValue: 'value' });
 
     expect(window.panorama).toHaveBeenCalledWith(
       'trackCustomEvent',
-      expect.objectContaining({ eventType: 'custom', eventValue: 'value' })
+      expect.objectContaining({ eventType: 'awsui', eventValue: 'value' })
     );
   });
 
   test('converts objects to strings', () => {
-    panorama.sendMetric({ eventType: 'custom', eventValue: { test: 'value' }, eventDetail: { test: 'detail' } });
+    panorama.sendMetric({ eventValue: { test: 'value' }, eventDetail: { test: 'detail' } });
 
     expect(window.panorama).toHaveBeenCalledWith(
       'trackCustomEvent',
-      expect.objectContaining({ eventType: 'custom', eventValue: '{"test":"value"}', eventDetail: '{"test":"detail"}' })
+      expect.objectContaining({ eventValue: '{"test":"value"}', eventDetail: '{"test":"detail"}' })
     );
   });
 
   test('prints an error when event details are too long', () => {
     const eventDetail = 'a'.repeat(4001);
-    panorama.sendMetric({ eventType: 'custom', eventDetail });
+    panorama.sendMetric({ eventContext: 'custom', eventDetail });
 
     expect(window.panorama).toHaveBeenCalledTimes(1);
     expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-      eventName: 'awsui-metric-error',
+      eventType: 'awsui',
+      eventContext: 'awsui-metric-error',
       eventDetail: expect.stringMatching(/Event detail for metric is too long:.*/),
+      timestamp: expect.any(Number),
     });
     expect(consoleSpy).toHaveBeenCalledWith(`Event detail for metric is too long: ${eventDetail}`);
-  });
-
-  test('prints an error when event type is too long', () => {
-    const eventType = 'a'.repeat(51);
-    const errorMessage = `Event type for metric is too long: ${eventType}`;
-    panorama.sendMetric({ eventType });
-
-    expect(window.panorama).toHaveBeenCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-      eventName: 'awsui-metric-error',
-      eventDetail: errorMessage,
-    });
-    expect(consoleSpy).toHaveBeenCalledWith(errorMessage);
-  });
-
-  test('prints an error when event name is too long', () => {
-    const eventName = 'a'.repeat(1001);
-    const errorMessage = `Event name for metric is too long: ${eventName}`;
-    panorama.sendMetric({ eventName });
-
-    expect(window.panorama).toHaveBeenCalledTimes(1);
-    expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-      eventName: 'awsui-metric-error',
-      eventDetail: errorMessage,
-    });
-    expect(consoleSpy).toHaveBeenCalledWith(errorMessage);
   });
 
   test('prints an error when event value is too long', () => {
@@ -84,8 +60,10 @@ describe('PanoramaClient', () => {
 
     expect(window.panorama).toHaveBeenCalledTimes(1);
     expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-      eventName: 'awsui-metric-error',
+      eventType: 'awsui',
+      eventContext: 'awsui-metric-error',
       eventDetail: expect.stringMatching(/Event value for metric is too long:.*/),
+      timestamp: expect.any(Number),
     });
     expect(consoleSpy).toHaveBeenCalledWith(`Event value for metric is too long: ${eventValue}`);
   });
@@ -96,8 +74,10 @@ describe('PanoramaClient', () => {
 
     expect(window.panorama).toHaveBeenCalledTimes(1);
     expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
-      eventName: 'awsui-metric-error',
+      eventType: 'awsui',
+      eventContext: 'awsui-metric-error',
       eventDetail: expect.stringMatching(/Event context for metric is too long:.*/),
+      timestamp: expect.any(Number),
     });
     expect(consoleSpy).toHaveBeenCalledWith(`Event context for metric is too long: ${eventContext}`);
   });


### PR DESCRIPTION
*Issue #, if available:* AWSUI-60324

*Description of changes:*

Fixing metrics according to the guidance from the Panorama API owners

* remove `eventName` as it is a legacy field
* always set `eventType: 'awsui'` for everything we emit to make it more discoverable among other entries
* set metric name as `eventContext`

The final hierarchy of the fields is the following: 

eventType (always "awsui" for us) -> eventContext (event in our system, typically a component usage) -> eventDetail (all metadata)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
