### PR TITLE
fix: Make sure clearVisualRefreshState helper removes the class too

### DIFF
--- a/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
+++ b/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
@@ -18,8 +18,10 @@ describe('useVisualRefresh', () => {
     return <div data-testid="current-mode">{isRefresh.toString()}</div>;
   }
 
-  beforeEach(() => clearVisualRefreshState());
-  afterEach(() => document.body.classList.remove('awsui-visual-refresh'));
+  afterEach(() => {
+    clearVisualRefreshState();
+    expect(document.querySelector('.awsui-visual-refresh')).toBeFalsy();
+  });
   afterEach(() => {
     clearMessageCache();
     jest.restoreAllMocks();

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -107,6 +107,9 @@ let visualRefreshState: undefined | boolean = undefined;
 // for testing
 export function clearVisualRefreshState() {
   visualRefreshState = undefined;
+  if (typeof document !== 'undefined') {
+    document.body.classList.remove('awsui-visual-refresh');
+  }
 }
 
 function detectVisualRefreshClassName() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This utility should live the pristine state


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
