### PR TITLE
chore: Expand AnalyticsMetadata to allow JSON objects

### DIFF
--- a/src/internal/base-component/metrics/interfaces.ts
+++ b/src/internal/base-component/metrics/interfaces.ts
@@ -18,7 +18,7 @@ export interface ComponentConfiguration {
   metadata?: Record<string, JSONValue>;
 }
 
-export type AnalyticsMetadata = Record<string, JSONValue>;
+export type AnalyticsMetadata = JSONObject;
 
 export interface MetricsLogItem {
   source: string;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current analytics metadata gets added to the DOM element but only supports primitives. When introducing errorContext we will be using an object and so expanding support for it here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
