### PR TITLE
chore: Internal unique ID utilities

### DIFF
--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -38,3 +38,4 @@ export { default as handleKey } from './utils/handle-key';
 export { default as circleIndex } from './utils/circle-index';
 export { default as Portal, PortalProps } from './portal';
 export { useMergeRefs } from './use-merge-refs';
+export { useRandomId, useUniqueId } from './use-unique-id';

--- a/src/internal/use-unique-id/__tests__/use-unique-id.test.tsx
+++ b/src/internal/use-unique-id/__tests__/use-unique-id.test.tsx
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { useUniqueId, useRandomId } from '../index';
+
+function DemoRandomIdComponent() {
+  const id = useRandomId();
+  return <div>{id}</div>;
+}
+
+function DemoUniqueIdComponent({ prefix }: { prefix: string }) {
+  const id = useUniqueId(prefix);
+  return <div>{id}</div>;
+}
+
+it('generates random ID per component', () => {
+  const component1 = render(<DemoRandomIdComponent />);
+  const textContent1 = component1.container.textContent;
+
+  const component2 = render(<DemoRandomIdComponent />);
+  const textContent2 = component2.container.textContent;
+
+  expect(textContent1).not.toBe('');
+  expect(textContent1).not.toBe(textContent2);
+
+  component1.rerender(<DemoRandomIdComponent />);
+  expect(component1.container.textContent).toBe(textContent1);
+});
+
+it('creates unique ID with given prefix', () => {
+  const component = render(<DemoUniqueIdComponent prefix="prefix-" />);
+
+  expect(component.container.textContent).toContain('prefix-');
+});

--- a/src/internal/use-unique-id/index.ts
+++ b/src/internal/use-unique-id/index.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useRef } from 'react';
+
+let counter = 0;
+export const useRandomId = () => {
+  const idRef = useRef<string | null>(null);
+  if (!idRef.current) {
+    idRef.current = `${counter++}-${Date.now()}-${Math.round(Math.random() * 10000)}`;
+  }
+  return idRef.current;
+};
+
+const useId: typeof useRandomId = (React as any).useId ?? useRandomId;
+
+export function useUniqueId(prefix?: string) {
+  return `${prefix ? prefix : ''}` + useId();
+}


### PR DESCRIPTION
Moving useRandomId and useUniqueId utils from components to toolkit to reuse for charts.

Rel: https://github.com/cloudscape-design/chart-components/pull/30

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
