### PR TITLE
chore: Bump tar-fs from 3.0.8 to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2860,21 +2860,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/@remix-run/router": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.5.0.tgz",
@@ -8372,21 +8357,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/geckodriver/node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
       }
     },
     "node_modules/geckodriver/node_modules/which": {
@@ -14719,6 +14689,21 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/tar-stream": {
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
@@ -17901,18 +17886,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
           "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
           "dev": true
-        },
-        "tar-fs": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-          "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
-          "dev": true,
-          "requires": {
-            "bare-fs": "^4.0.1",
-            "bare-path": "^3.0.0",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
         }
       }
     },
@@ -21840,18 +21813,6 @@
             "data-uri-to-buffer": "^4.0.0",
             "fetch-blob": "^3.1.4",
             "formdata-polyfill": "^4.0.10"
-          }
-        },
-        "tar-fs": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-          "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
-          "dev": true,
-          "requires": {
-            "bare-fs": "^4.0.1",
-            "bare-path": "^3.0.0",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
           }
         },
         "which": {
@@ -26445,6 +26406,18 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tar-fs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "dev": true,
+      "requires": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
     },
     "tar-stream": {
       "version": "3.1.7",


### PR DESCRIPTION
Diff in between those versions: https://github.com/mafintosh/tar-fs/compare/v3.0.8...v3.1.0

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
