### PR TITLE
fix: Move validate-props method to component-toolkit package

### DIFF
--- a/src/internal/base-component/__tests__/validate-props-production.test.tsx
+++ b/src/internal/base-component/__tests__/validate-props-production.test.tsx
@@ -1,0 +1,12 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { validateProps } from '../../../../lib/internal/base-component/validate-props';
+import { isDevelopment } from '../../../../lib/internal/is-development';
+
+jest.mock('../../../../lib/components/internal/is-development', () => ({ isDevelopment: false }));
+
+test('does nothing in production builds', () => {
+  expect(isDevelopment).toBe(false);
+  expect(() => validateProps('TestComponent', { variant: 'foo' }, ['variant'], {})).not.toThrow();
+});

--- a/src/internal/base-component/__tests__/validate-props.test.tsx
+++ b/src/internal/base-component/__tests__/validate-props.test.tsx
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { validateProps } from '../../../../lib/internal/base-component/validate-props';
+
+test('should pass validation', () => {
+  expect(() => validateProps('TestComponent', {}, [], {})).not.toThrow();
+  expect(() => validateProps('TestComponent', { variant: 'foo' }, ['bar'], { variant: ['foo'] })).not.toThrow();
+  expect(() => validateProps('TestComponent', { variant: undefined }, ['bar'], { variant: ['foo'] })).not.toThrow();
+});
+
+test('should throw error when excluded prop is used', () => {
+  expect(() => validateProps('TestComponent', { variant: 'foo' }, ['variant'], {})).toThrow(
+    new Error('TestComponent does not support "variant" property when used in default theme')
+  );
+});
+
+test('should throw error when invalid prop is used', () => {
+  expect(() => validateProps('TestComponent', { variant: 'foo' }, [], { variant: ['bar'] })).toThrow(
+    new Error('TestComponent does not support "variant" with value "foo" when used in default theme')
+  );
+});


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
