### PR TITLE
fix: Avoid stale state in singleton-handler

### DIFF
--- a/src/internal/singleton-handler/index.ts
+++ b/src/internal/singleton-handler/index.ts
@@ -46,13 +46,9 @@ interface SingletonStateOptions<T> {
 
 export function createSingletonState<T>({ factory, initialState }: SingletonStateOptions<T>) {
   const useSingleton = createSingletonHandler(factory);
-  let value = initialState;
   return function useSingletonState() {
-    const [state, setState] = useState<T>(value);
-    useSingleton(newValue => {
-      value = newValue;
-      setState(newValue);
-    });
+    const [state, setState] = useState<T>(initialState);
+    useSingleton(setState);
     return state;
   };
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

> _There are only two hard things in Computer Science: cache invalidation and naming things._

In this PR we got incorrect caching.

This affects our `useMobile` hook. Example:


```js
test('first', () => {
  globalThis[forceMobileModeSymbol] = false;
  render(<AppLayout />); // I see desktop view

  // resize to mobile
  act(() => {
    globalThis[forceMobileModeSymbol] = true;
    window.dispatchEvent(new CustomEvent('resize'));
  });

  // clean up flag to its original state
  globalThis[forceMobileModeSymbol] = undefined;
});

test('second', () => {
  // no overrides in this test, it should be desktop by default, but the mobile size is leaked from the previous test
  render(<AppLayout />);
});
```

With the fix the "second" test will work as expected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
