### PR TITLE
allow booleans and numbers in metric detail

### DIFF
--- a/src/internal/base-component/__tests__/metrics.test.ts
+++ b/src/internal/base-component/__tests__/metrics.test.ts
@@ -222,6 +222,17 @@ describe('Client Metrics support', () => {
       });
     });
 
+    test('supports string, number and boolean details', () => {
+      metrics.sendOpsMetricObject('awsui-ops-demo', { count: 1, value: 'a', enabled: true });
+      expect(window.panorama).toHaveBeenCalledWith('trackCustomEvent', {
+        eventType: 'awsui',
+        eventContext: 'awsui-ops-demo',
+        eventDetail: '{"o":"main","t":"default","f":"react","v":"1.0","count":1,"value":"a","enabled":true}',
+        eventValue: '1',
+        timestamp: expect.any(Number),
+      });
+    });
+
     test('deduplicates metrics with same details', () => {
       metrics.sendOpsMetricObject('awsui-ops-demo', { foo: 'something' });
       metrics.sendOpsMetricObject('awsui-ops-demo', { foo: 'something' });

--- a/src/internal/base-component/metrics/metrics.ts
+++ b/src/internal/base-component/metrics/metrics.ts
@@ -51,7 +51,7 @@ export class Metrics {
     this.panorama.sendMetric(metric);
   }
 
-  sendOpsMetricObject(metricName: string, detail: Record<string, string>) {
+  sendOpsMetricObject(metricName: string, detail: Record<string, string | number | boolean>) {
     this.sendMetricOnce(metricName, 1, buildMetricDetail(detail, this.context));
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This works today, but not allowed by types

```
metrics.sendOpsMetricObject('awsui-ops-demo', { somethingCount: 1 });
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
