### PR TITLE
chore: Export TestSingleTabStopNavigationProvider to avoid a dependency on RTL

### DIFF
--- a/src/internal/single-tab-stop/__tests__/context.test.tsx
+++ b/src/internal/single-tab-stop/__tests__/context.test.tsx
@@ -11,7 +11,11 @@ import {
   SingleTabStopNavigationReset,
   useSingleTabStopNavigation,
 } from '../';
-import { renderWithSingleTabStopNavigation } from './utils';
+import {
+  setTestSingleTabStopNavigationTarget,
+  renderWithSingleTabStopNavigation,
+  TestSingleTabStopNavigationProvider,
+} from '../test-helpers';
 
 // Simple STSN subscriber component
 function Button(props: React.HTMLAttributes<HTMLButtonElement>) {
@@ -56,6 +60,15 @@ function findGroupButton(groupId: string, buttonIndex: number) {
 }
 
 test('does not override tab index when keyboard navigation is not active', () => {
+  render(
+    <TestSingleTabStopNavigationProvider navigationActive={false}>
+      <Button id="button" />
+    </TestSingleTabStopNavigationProvider>
+  );
+  expect(document.querySelector('#button')).not.toHaveAttribute('tabIndex');
+});
+
+test('(legacy coverage) does not override tab index when keyboard navigation is not active', () => {
   renderWithSingleTabStopNavigation(<Button id="button" />, { navigationActive: false });
   expect(document.querySelector('#button')).not.toHaveAttribute('tabIndex');
 });
@@ -84,6 +97,18 @@ test('does not override tab index for suppressed elements', () => {
 });
 
 test('overrides tab index when keyboard navigation is active', () => {
+  render(
+    <TestSingleTabStopNavigationProvider navigationActive={true}>
+      <Button id="button1" />
+      <Button id="button2" />
+    </TestSingleTabStopNavigationProvider>
+  );
+  setTestSingleTabStopNavigationTarget(document.querySelector('#button1'));
+  expect(document.querySelector('#button1')).toHaveAttribute('tabIndex', '0');
+  expect(document.querySelector('#button2')).toHaveAttribute('tabIndex', '-1');
+});
+
+test('(legacy coverage) overrides tab index when keyboard navigation is active', () => {
   const { setCurrentTarget } = renderWithSingleTabStopNavigation(
     <div>
       <Button id="button1" />

--- a/src/internal/testing.ts
+++ b/src/internal/testing.ts
@@ -5,4 +5,8 @@ export { clearOneTimeMetricsCache } from './base-component/metrics/metrics';
 export { clearMessageCache } from './logging';
 export { setGlobalFlag } from './global-flags';
 export { clearVisualRefreshState } from './visual-mode';
-export { renderWithSingleTabStopNavigation } from './single-tab-stop/__tests__/utils';
+export {
+  renderWithSingleTabStopNavigation,
+  TestSingleTabStopNavigationProvider,
+  setTestSingleTabStopNavigationTarget,
+} from './single-tab-stop/test-helpers';


### PR DESCRIPTION
The currently exported `renderWithSingleTabStopNavigation` util requires a dependency on the react testing library. To avoid having this dependency, we export `TestSingleTabStopNavigationProvider` and `setTestSingleTabStopNavigationTarget` helpers instead. Once components code is migrated, the `renderWithSingleTabStopNavigation` export will be removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
