### PR TITLE
feat: Pass package source name in component usage metric

### DIFF
--- a/src/internal/base-component/__tests__/metrics.test.ts
+++ b/src/internal/base-component/__tests__/metrics.test.ts
@@ -276,6 +276,7 @@ describe('Client Metrics support', () => {
             v: testCase[1][1],
             a: 'used',
             s: 'DummyComponentName',
+            p: 'pkg',
             c: { props: {} },
           });
         });
@@ -293,6 +294,7 @@ describe('Client Metrics support', () => {
         v: '1.0',
         a: 'used',
         s: 'DummyComponentName',
+        p: 'dummy-package',
         c: { props: {} },
       });
     });
@@ -306,6 +308,7 @@ describe('Client Metrics support', () => {
         v: '1.0',
         a: 'used',
         s: 'DummyComponentName',
+        p: 'dummy-package',
         c: { props: { variant: 'primary' }, metadata: { isMobile: true } },
       });
     });
@@ -322,6 +325,7 @@ describe('Client Metrics support', () => {
         v: '1.0',
         a: 'used',
         s: 'DummyComponentName',
+        p: 'dummy-package',
         c: { props: {}, metadata: { nullValue: null } },
       });
     });
@@ -337,6 +341,7 @@ describe('Client Metrics support', () => {
         v: '1.0',
         a: 'used',
         s: 'DummyComponentName',
+        p: 'dummy-package',
         c: { props: { count: 123, notANumber: 'NaN', maxSize: 'Infinity' } },
       });
     });

--- a/src/internal/base-component/__tests__/use-component-metrics.test.tsx
+++ b/src/internal/base-component/__tests__/use-component-metrics.test.tsx
@@ -87,6 +87,7 @@ describe('useComponentMetrics', () => {
         v: '3.0.0',
         a: 'used',
         s: 'test-component-1',
+        p: 'toolkit',
         c: { props: {} },
       })
     );
@@ -113,6 +114,7 @@ describe('useComponentMetrics', () => {
         v: '3.0.0',
         a: 'used',
         s: 'test-component-2',
+        p: 'toolkit',
         c: { props: {} },
       })
     );
@@ -133,6 +135,7 @@ describe('useComponentMetrics', () => {
       v: '3.0.0',
       a: 'used',
       s: 'test-component-with-props',
+      p: 'toolkit',
     };
     expect(window.AWSC.Clog.log).toHaveBeenCalledTimes(1);
     expect(window.AWSC.Clog.log).toHaveBeenCalledWith(
@@ -165,6 +168,7 @@ describe('useComponentMetrics', () => {
         v: '3.0.0',
         a: 'used',
         s: 'test-component-1',
+        p: 'toolkit',
         c: { props: {} },
       })
     );

--- a/src/internal/base-component/metrics/formatters.ts
+++ b/src/internal/base-component/metrics/formatters.ts
@@ -20,13 +20,14 @@ export function buildMetricDetail(detail: JSONObject, context: PackageSettings):
 }
 
 export function buildComponentMetricDetail(
-  { componentName, action, configuration }: ComponentMetricDetail,
+  { componentName, action, configuration, packageSource }: ComponentMetricDetail,
   context: PackageSettings
 ): string {
   return buildMetricDetail(
     {
       a: action,
       s: componentName,
+      p: packageSource,
       c: configuration as JSONObject | undefined,
     },
     context

--- a/src/internal/base-component/metrics/interfaces.ts
+++ b/src/internal/base-component/metrics/interfaces.ts
@@ -27,6 +27,7 @@ export interface ComponentMetricDetail {
   // "used" – individual component used
   action: 'loaded' | 'used';
   configuration?: ComponentConfiguration;
+  packageSource?: string;
 }
 
 export interface ComponentMetricMinified {
@@ -44,4 +45,6 @@ export interface ComponentMetricMinified {
   v: string;
   // component configuration
   c?: JSONObject;
+  // package name
+  p?: string;
 }

--- a/src/internal/base-component/metrics/metrics.ts
+++ b/src/internal/base-component/metrics/metrics.ts
@@ -78,6 +78,7 @@ export class Metrics {
       action: 'used',
       componentName,
       configuration,
+      packageSource: this.context.packageSource,
     });
   }
 }


### PR DESCRIPTION
*Description of changes:* Pass package name along with component metrics so that we can distinguish from components from different packages that have the same name (motivation: Pie Chart from Components vs Pie Chart from Chart Components).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
