### PR TITLE
chore: Removes deprecated stsn test helper

### DIFF
--- a/src/internal/single-tab-stop/__tests__/context.test.tsx
+++ b/src/internal/single-tab-stop/__tests__/context.test.tsx
@@ -11,11 +11,7 @@ import {
   SingleTabStopNavigationReset,
   useSingleTabStopNavigation,
 } from '../';
-import {
-  setTestSingleTabStopNavigationTarget,
-  renderWithSingleTabStopNavigation,
-  TestSingleTabStopNavigationProvider,
-} from '../test-helpers';
+import { setTestSingleTabStopNavigationTarget, TestSingleTabStopNavigationProvider } from '../test-helpers';
 
 // Simple STSN subscriber component
 function Button(props: React.HTMLAttributes<HTMLButtonElement>) {
@@ -69,22 +65,25 @@ test('does not override tab index when keyboard navigation is not active', () =>
 });
 
 test('(legacy coverage) does not override tab index when keyboard navigation is not active', () => {
-  renderWithSingleTabStopNavigation(<Button id="button" />, { navigationActive: false });
+  render(
+    <TestSingleTabStopNavigationProvider navigationActive={false}>
+      <Button id="button" />
+    </TestSingleTabStopNavigationProvider>
+  );
   expect(document.querySelector('#button')).not.toHaveAttribute('tabIndex');
 });
 
 test('does not override tab index for suppressed elements', () => {
-  const { setCurrentTarget } = renderWithSingleTabStopNavigation(
-    <div>
+  render(
+    <TestSingleTabStopNavigationProvider navigationActive={true}>
       <Button id="button1" />
       <Button id="button2" />
       <Button id="button3" tabIndex={-1} />
       <Button id="button4" />
       <Button id="button5" tabIndex={-1} />
-    </div>,
-    { navigationActive: true }
+    </TestSingleTabStopNavigationProvider>
   );
-  setCurrentTarget(document.querySelector('#button1'), [
+  setTestSingleTabStopNavigationTarget(document.querySelector('#button1'), [
     document.querySelector('#button1'),
     document.querySelector('#button2'),
     document.querySelector('#button3'),
@@ -109,25 +108,25 @@ test('overrides tab index when keyboard navigation is active', () => {
 });
 
 test('(legacy coverage) overrides tab index when keyboard navigation is active', () => {
-  const { setCurrentTarget } = renderWithSingleTabStopNavigation(
-    <div>
+  render(
+    <TestSingleTabStopNavigationProvider navigationActive={true}>
       <Button id="button1" />
       <Button id="button2" />
-    </div>
+    </TestSingleTabStopNavigationProvider>
   );
-  setCurrentTarget(document.querySelector('#button1'));
+  setTestSingleTabStopNavigationTarget(document.querySelector('#button1'));
   expect(document.querySelector('#button1')).toHaveAttribute('tabIndex', '0');
   expect(document.querySelector('#button2')).toHaveAttribute('tabIndex', '-1');
 });
 
 test('does not override explicit tab index with 0', () => {
-  const { setCurrentTarget } = renderWithSingleTabStopNavigation(
-    <div>
+  render(
+    <TestSingleTabStopNavigationProvider navigationActive={true}>
       <Button id="button1" tabIndex={-2} />
       <Button id="button2" tabIndex={-2} />
-    </div>
+    </TestSingleTabStopNavigationProvider>
   );
-  setCurrentTarget(document.querySelector('#button1'));
+  setTestSingleTabStopNavigationTarget(document.querySelector('#button1'));
   expect(document.querySelector('#button1')).toHaveAttribute('tabIndex', '-2');
   expect(document.querySelector('#button2')).toHaveAttribute('tabIndex', '-2');
 });

--- a/src/internal/single-tab-stop/test-helpers/index.tsx
+++ b/src/internal/single-tab-stop/test-helpers/index.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React, { forwardRef, useCallback, useEffect, useRef } from 'react';
-import { render } from '@testing-library/react';
 
 import { FocusableChangeHandler, SingleTabStopNavigationContext } from '../';
 import { useUniqueId } from '../../use-unique-id';
@@ -57,20 +56,3 @@ export const TestSingleTabStopNavigationProvider = forwardRef(
 export const setTestSingleTabStopNavigationTarget: SetTarget = (focusTarget, suppressed) => {
   Array.from(providerRegistry).forEach(([, provider]) => provider.setCurrentTarget(focusTarget, suppressed));
 };
-
-/**
- * @deprecated - Use TestSingleTabStopNavigationProvider instead
- */
-export function renderWithSingleTabStopNavigation(
-  ui: React.ReactNode,
-  { navigationActive = true }: { navigationActive?: boolean } = {}
-) {
-  const { container, rerender } = render(
-    <TestSingleTabStopNavigationProvider navigationActive={navigationActive}>{ui}</TestSingleTabStopNavigationProvider>
-  );
-  return {
-    container,
-    rerender,
-    setCurrentTarget: setTestSingleTabStopNavigationTarget,
-  };
-}

--- a/src/internal/testing.ts
+++ b/src/internal/testing.ts
@@ -6,7 +6,6 @@ export { clearMessageCache } from './logging';
 export { setGlobalFlag } from './global-flags';
 export { clearVisualRefreshState } from './visual-mode';
 export {
-  renderWithSingleTabStopNavigation,
   TestSingleTabStopNavigationProvider,
   setTestSingleTabStopNavigationTarget,
 } from './single-tab-stop/test-helpers';


### PR DESCRIPTION
Removing deprecated test helper to avoid a dependency on React Testing Library.

Rel: AWSUI-61217

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
