### PR TITLE
fix: guard against empty ResizeObserver size arrays

### DIFF
--- a/src/internal/container-queries/use-resize-observer.ts
+++ b/src/internal/container-queries/use-resize-observer.ts
@@ -74,10 +74,10 @@ export function useResizeObserver(elementRef: ElementReference, onObserve: (entr
 function convertResizeObserverEntry(entry: ResizeObserverEntry): ContainerQueryEntry {
   return {
     target: entry.target,
-    contentBoxWidth: entry.contentBoxSize[0].inlineSize,
-    contentBoxHeight: entry.contentBoxSize[0].blockSize,
-    borderBoxWidth: entry.borderBoxSize[0].inlineSize,
-    borderBoxHeight: entry.borderBoxSize[0].blockSize,
+    contentBoxWidth: entry.contentBoxSize[0]?.inlineSize || 0,
+    contentBoxHeight: entry.contentBoxSize[0]?.blockSize || 0,
+    borderBoxWidth: entry.borderBoxSize[0]?.inlineSize || 0,
+    borderBoxHeight: entry.borderBoxSize[0]?.blockSize || 0,
   };
 }
 


### PR DESCRIPTION
*Description of changes:*

add optional chaining for `contentBoxSize` and `borderBoxSize` array.
prevents TypeError when `contentBoxSize` or `borderBoxSize` arrays are empty in certain browser implementations or edge cases.

--- 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
