### PR TITLE
fix: Default to OwnerDocument for Portal Container

### DIFF
--- a/src/internal/portal/__tests__/portal.test.tsx
+++ b/src/internal/portal/__tests__/portal.test.tsx
@@ -7,9 +7,12 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { warnOnce } from '../../logging';
 import Portal, { PortalProps } from '../index';
 
-function renderPortal(props: PortalProps) {
-  const { rerender, unmount } = render(<Portal {...props} />);
-  return { unmount, rerender: (props: PortalProps) => rerender(<Portal {...props} />) };
+function renderPortal(props: PortalProps, options?: { container?: HTMLElement }) {
+  const { rerender, unmount } = render(<Portal {...props} />, options);
+  return {
+    unmount,
+    rerender: (props: PortalProps) => rerender(<Portal {...props} />),
+  };
 }
 
 jest.mock('../../logging', () => ({
@@ -229,6 +232,56 @@ describe('Portal', () => {
       unmount();
       expect(document.querySelectorAll('body > div').length).toBe(1);
       expect(document.querySelector('body > div')?.innerHTML).toBe('');
+    });
+  });
+
+  describe('iframe support', () => {
+    let iframe: HTMLIFrameElement;
+    let iframeDocument: Document;
+
+    beforeEach(() => {
+      iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      iframeDocument = iframe.contentDocument!;
+    });
+
+    afterEach(() => {
+      iframe.remove();
+    });
+
+    function renderInIframe(props: PortalProps) {
+      const iframeRoot = iframeDocument.createElement('div');
+      iframeDocument.body.appendChild(iframeRoot);
+      return renderPortal(props, { container: iframeRoot });
+    }
+
+    test('renders to the ownerDocument when mounted inside an iframe', () => {
+      const { unmount } = renderInIframe({ children: <p data-testid="iframe-content">Inside iframe</p> });
+
+      expect(iframeDocument.querySelector('p[data-testid="iframe-content"]')).toBeTruthy();
+      expect(iframeDocument.body.contains(iframeDocument.querySelector('p[data-testid="iframe-content"]'))).toBe(true);
+
+      unmount();
+    });
+
+    test('does not render to the parent document when inside an iframe', () => {
+      const { unmount } = renderInIframe({ children: <p data-testid="iframe-content">Inside iframe</p> });
+
+      expect(document.querySelectorAll('p[data-testid="iframe-content"]').length).toBe(0);
+
+      unmount();
+    });
+
+    test('cleans up container from iframe document on unmount', () => {
+      const { unmount } = renderInIframe({ children: <p>Inside iframe</p> });
+
+      const containersBefore = iframeDocument.querySelectorAll('body > div').length;
+      expect(containersBefore).toBeGreaterThanOrEqual(2);
+
+      unmount();
+
+      const containersAfter = iframeDocument.querySelectorAll('body > div').length;
+      expect(containersAfter).toBe(containersBefore - 1);
     });
   });
 });

--- a/src/internal/portal/index.tsx
+++ b/src/internal/portal/index.tsx
@@ -60,7 +60,7 @@ export default function Portal({
   getContainer,
   removeContainer,
   children,
-}: PortalProps): React.ReactPortal | React.ReactElement {
+}: PortalProps): React.ReactPortal | React.ReactElement | null {
   const [activeContainer, setActiveContainer] = useState<Element | null>(container ?? null);
   const ref = React.useRef<HTMLSpanElement>(null);
 
@@ -85,9 +85,9 @@ export default function Portal({
     return manageDefaultContainer(ownerDocument, setActiveContainer);
   }, [container, getContainer, removeContainer]);
 
-  if (!activeContainer) {
+  if (!activeContainer && typeof document !== 'undefined') {
     return <span ref={ref} style={{ display: 'none' }} />;
   }
 
-  return createPortal(children, activeContainer);
+  return activeContainer && createPortal(children, activeContainer);
 }

--- a/src/internal/portal/index.tsx
+++ b/src/internal/portal/index.tsx
@@ -85,6 +85,10 @@ export default function Portal({
     return manageDefaultContainer(ownerDocument, setActiveContainer);
   }, [container, getContainer, removeContainer]);
 
+  // On the first render, activeContainer is null because the layout effect hasn't
+  // created it yet. We render a hidden probe span so the effect can read
+  // ref.current.ownerDocument to discover the correct document (e.g. inside iframes).
+  // In SSR there's no document, so we return null to match the previous behavior.
   if (!activeContainer && typeof document !== 'undefined') {
     return <span ref={ref} style={{ display: 'none' }} />;
   }

--- a/src/internal/portal/index.tsx
+++ b/src/internal/portal/index.tsx
@@ -55,7 +55,12 @@ function manageAsyncContainer(
  * If a node isn't provided, it creates one under the owner document's body,
  * ensuring correct behavior inside iframes.
  */
-export default function Portal({ container, getContainer, removeContainer, children }: PortalProps) {
+export default function Portal({
+  container,
+  getContainer,
+  removeContainer,
+  children,
+}: PortalProps): React.ReactPortal | React.ReactElement {
   const [activeContainer, setActiveContainer] = useState<Element | null>(container ?? null);
   const ref = React.useRef<HTMLSpanElement>(null);
 

--- a/src/internal/portal/index.tsx
+++ b/src/internal/portal/index.tsx
@@ -13,12 +13,15 @@ export interface PortalProps {
   children: React.ReactNode;
 }
 
-function manageDefaultContainer(setState: React.Dispatch<React.SetStateAction<Element | null>>) {
-  const newContainer = document.createElement('div');
-  document.body.appendChild(newContainer);
+function manageDefaultContainer(
+  ownerDocument: Document,
+  setState: React.Dispatch<React.SetStateAction<Element | null>>
+) {
+  const newContainer = ownerDocument.createElement('div');
+  ownerDocument.body.appendChild(newContainer);
   setState(newContainer);
   return () => {
-    document.body.removeChild(newContainer);
+    ownerDocument.body.removeChild(newContainer);
   };
 }
 
@@ -49,10 +52,12 @@ function manageAsyncContainer(
 
 /**
  * A safe react portal component that renders to a provided node.
- * If a node isn't provided, it creates one under document.body.
+ * If a node isn't provided, it creates one under the owner document's body,
+ * ensuring correct behavior inside iframes.
  */
 export default function Portal({ container, getContainer, removeContainer, children }: PortalProps) {
   const [activeContainer, setActiveContainer] = useState<Element | null>(container ?? null);
+  const ref = React.useRef<HTMLSpanElement>(null);
 
   useLayoutEffect(() => {
     if (container) {
@@ -70,8 +75,14 @@ export default function Portal({ container, getContainer, removeContainer, child
     if (getContainer && removeContainer) {
       return manageAsyncContainer(getContainer, removeContainer, setActiveContainer);
     }
-    return manageDefaultContainer(setActiveContainer);
+
+    const ownerDocument = ref.current?.ownerDocument ?? document;
+    return manageDefaultContainer(ownerDocument, setActiveContainer);
   }, [container, getContainer, removeContainer]);
 
-  return activeContainer && createPortal(children, activeContainer);
+  if (!activeContainer) {
+    return <span ref={ref} style={{ display: 'none' }} />;
+  }
+
+  return createPortal(children, activeContainer);
 }


### PR DESCRIPTION
When container is not provided the Portal is created in the top most document of the window resulting in broken experience with out components when used in an iframe. Instead of fixing each case of Portal use fixing the issue here by making default behavior to go for the owner document for portal div creation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
