### PR TITLE
feat: Extract component description from aria-describedby

### DIFF
--- a/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
+++ b/src/internal/analytics-metadata/__tests__/metadata-utils.test.ts
@@ -337,6 +337,110 @@ describe('processMetadata', () => {
 
     document.body.removeChild(mockDiv);
   });
+
+  test('extracts component description from aria-describedby on label element', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <span id="desc-1">Must be 3-20 characters</span>
+      <input aria-describedby="desc-1" />
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, { name: 'awsui.Input', label: 'input' });
+    expect(result.description).toBe('Must be 3-20 characters');
+
+    document.body.removeChild(mockDiv);
+  });
+
+  test('concatenates multiple aria-describedby IDs', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <span id="desc-a">Enter your work email</span>
+      <span id="desc-b">Must end with @amazon.com</span>
+      <input aria-describedby="desc-a desc-b" />
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, { name: 'awsui.Input', label: 'input' });
+    expect(result.description).toBe('Enter your work email Must end with @amazon.com');
+
+    document.body.removeChild(mockDiv);
+  });
+
+  test('does not extract description when label element has no aria-describedby', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <label class="label">Form field label</label>
+      <div id="ff-desc">This is a description</div>
+      <input aria-describedby="ff-desc" />
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, { name: 'awsui.FormField', label: '.label' });
+    expect(result.description).toBeUndefined();
+
+    document.body.removeChild(mockDiv);
+  });
+
+  test('does not extract description when component has no label selector', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <span id="desc-1">Some description</span>
+      <input aria-describedby="desc-1" />
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, { name: 'awsui.Input' });
+    expect(result.description).toBeUndefined();
+
+    document.body.removeChild(mockDiv);
+  });
+
+  test('does not extract description from child elements', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <div id="ff-desc">This is a description</div>
+      <input aria-describedby="ff-desc" />
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, { name: 'awsui.FormField', label: '.label' });
+    expect(result.description).toBeUndefined();
+
+    document.body.removeChild(mockDiv);
+  });
+
+  test('skips missing IDs in aria-describedby', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <span id="desc-exists">Constraint text</span>
+      <input aria-describedby="desc-missing desc-exists" />
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, { name: 'awsui.Input', label: 'input' });
+    expect(result.description).toBe('Constraint text');
+
+    document.body.removeChild(mockDiv);
+  });
+
+  test('extracts description when label is a LabelIdentifier with array selector', () => {
+    const mockDiv = document.createElement('div');
+    mockDiv.innerHTML = `
+      <span id="desc-1">Help text</span>
+      <span class="header">Title</span>
+      <button class="trigger" aria-describedby="desc-1">Select</button>
+    `;
+    document.body.appendChild(mockDiv);
+
+    const result: any = processMetadata(mockDiv, {
+      name: 'awsui.Select',
+      label: { selector: ['.header', '.trigger'] },
+    });
+    expect(result.description).toBe('Help text');
+
+    document.body.removeChild(mockDiv);
+  });
 });
 
 describe('merge', () => {

--- a/src/internal/analytics-metadata/metadata-utils.ts
+++ b/src/internal/analytics-metadata/metadata-utils.ts
@@ -22,7 +22,7 @@ export const processMetadata = (
   localMetadata: any,
   options?: GetComponentsTreeOptions
 ): GeneratedAnalyticsMetadataFragment => {
-  return Object.keys(localMetadata).reduce((acc: any, key: string) => {
+  const result: any = Object.keys(localMetadata).reduce((acc: any, key: string) => {
     if (key.toLowerCase().match(/labels$/)) {
       acc[key] = processLabel(node, localMetadata[key], 'multi');
     } else if (key.toLowerCase().match(/label$/)) {
@@ -68,6 +68,15 @@ export const processMetadata = (
     }
     return acc;
   }, {});
+
+  if (result.name && node && localMetadata.label) {
+    const description = resolveComponentDescription(node, localMetadata.label);
+    if (description) {
+      result.description = description;
+    }
+  }
+
+  return result;
 };
 
 const isNil = (value: any) => {
@@ -155,6 +164,31 @@ const resolveInputDescription = (root: HTMLElement, input: HTMLElement): string 
     const doc = root.ownerDocument || document;
     const descEl = doc.getElementById(describedBy.split(' ')[0]);
     return descEl?.textContent?.trim() || '';
+  }
+  return '';
+};
+
+const resolveComponentDescription = (node: HTMLElement, label: string | { selector?: string | string[] }): string => {
+  const selectors =
+    typeof label === 'string' ? [label] : Array.isArray(label.selector) ? label.selector : [label.selector || ''];
+  const doc = node.ownerDocument || document;
+  for (const selector of selectors) {
+    const el = selector ? node.querySelector(selector) : node;
+    if (!el) {
+      continue;
+    }
+    const describedBy = el.getAttribute('aria-describedby');
+    if (!describedBy) {
+      continue;
+    }
+    const description = describedBy
+      .split(' ')
+      .map(id => doc.getElementById(id)?.textContent?.trim() || '')
+      .filter(Boolean)
+      .join(' ');
+    if (description) {
+      return description;
+    }
   }
   return '';
 };

--- a/src/internal/analytics-metadata/page-scanner-utils.ts
+++ b/src/internal/analytics-metadata/page-scanner-utils.ts
@@ -8,6 +8,7 @@ import { getGeneratedAnalyticsMetadata } from './utils.js';
 interface GeneratedAnalyticsMetadataComponentTree {
   name: string;
   label: string;
+  description?: string;
   properties?: Record<string, string | Array<string> | Array<Array<string>> | Array<OptionItem> | Array<TabItem>>;
   children?: Array<GeneratedAnalyticsMetadataComponentTree>;
 }


### PR DESCRIPTION
## Description

Adds a `description` field to the component metadata tree output. The description is extracted by resolving `aria-describedby` on the same element used for label resolution (found via the component's label selector). All space-separated IDs are resolved and their text content concatenated, matching screen reader behavior.

This works because `aria-labelledby` and `aria-describedby` are always placed on the same interactive control element in Cloudscape components. FormField is correctly excluded since its label selector points to a `<label>` element which does not have `aria-describedby`.

## Example output

For an Input inside a FormField with `constraintText="Must be 3-20 characters"`:

```json
{
  "name": "awsui.Input",
  "label": "Username",
  "description": "Must be 3-20 characters",
  "properties": { "value": "..." }
}
```

## Changes

- Added `description?: string` to `GeneratedAnalyticsMetadataComponentTree` interface
- Added `resolveComponentDescription` helper that uses the label selector to find the element, checks `aria-describedby`, and concatenates all referenced IDs' text content. Iterates through array selectors (like label resolution) returning the first match.
- Integrated into `processMetadata`: description is extracted when a component has `name` and a label selector defined
- 7 new unit tests covering: basic extraction, multi-ID concatenation, no describedby, no label selector, label element without describedby, missing IDs, array selector fallback

## Testing

All 412 unit tests pass.

Components unit tests in dry run expected to fail because 1) of as-yet in-pipeline diffs from a previous PR, 2) expected diffs from this PR (`description` now provided in some of the test cases)