### PR TITLE
feat: detect one-theme as visual refresh via class and global flag

### DIFF
--- a/src/internal/global-flags/index.ts
+++ b/src/internal/global-flags/index.ts
@@ -8,6 +8,7 @@ interface GlobalFlags {
   appLayoutWidget?: boolean;
   appLayoutToolbar?: boolean;
   analyticsMetadata?: boolean;
+  oneTheme?: boolean;
 }
 
 export interface FlagsHolder {

--- a/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
+++ b/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
@@ -21,6 +21,7 @@ describe('useVisualRefresh', () => {
   afterEach(() => {
     clearVisualRefreshState();
     expect(document.querySelector('.awsui-visual-refresh')).toBeFalsy();
+    expect(document.querySelector('.awsui-one-theme')).toBeFalsy();
   });
   afterEach(() => {
     clearMessageCache();
@@ -34,6 +35,12 @@ describe('useVisualRefresh', () => {
 
   test('should return true when class name is present', () => {
     document.body.classList.add('awsui-visual-refresh');
+    render(<App />);
+    expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+  });
+
+  test('should return true when awsui-one-theme class name is present', () => {
+    document.body.classList.add('awsui-one-theme');
     render(<App />);
     expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
   });
@@ -79,6 +86,20 @@ describe('useVisualRefresh', () => {
     test('should return true when Window Symbol awsui-visual-refresh-flag returns false but class name is present', () => {
       document.body.classList.add('awsui-visual-refresh');
       window[awsuiVisualRefreshFlag] = () => false;
+      render(<App />);
+      expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
+    });
+  });
+
+  describe('oneTheme global flag', () => {
+    const awsuiGlobalFlagsSymbol = Symbol.for('awsui-global-flags');
+
+    afterEach(() => {
+      delete (window as any)[awsuiGlobalFlagsSymbol];
+    });
+
+    test('should return true when oneTheme global flag is set', () => {
+      (window as any)[awsuiGlobalFlagsSymbol] = { oneTheme: true };
       render(<App />);
       expect(screen.getByTestId('current-mode')).toHaveTextContent('true');
     });

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -7,7 +7,7 @@ import { createSingletonHandler } from '../singleton-handler/index.js';
 import { useStableCallback } from '../stable-callback/index.js';
 import { isDevelopment } from '../is-development.js';
 import { warnOnce } from '../logging.js';
-import { awsuiVisualRefreshFlag, getGlobal } from '../global-flags/index.js';
+import { awsuiVisualRefreshFlag, getGlobal, getGlobalFlag } from '../global-flags/index.js';
 import { safeMatchMedia } from '../utils/safe-match-media.js';
 
 export function isMotionDisabled(element: HTMLElement): boolean {
@@ -100,16 +100,17 @@ export function clearVisualRefreshState() {
   visualRefreshState = undefined;
   if (typeof document !== 'undefined') {
     document.body.classList.remove('awsui-visual-refresh');
+    document.body.classList.remove('awsui-one-theme');
   }
 }
 
 function detectVisualRefreshClassName() {
-  return typeof document !== 'undefined' && !!document.querySelector('.awsui-visual-refresh');
+  return typeof document !== 'undefined' && !!document.querySelector('.awsui-visual-refresh, .awsui-one-theme');
 }
 
 function detectVisualRefreshFlag() {
   const global = getGlobal();
-  return global?.[awsuiVisualRefreshFlag]?.() ?? false;
+  return global?.[awsuiVisualRefreshFlag]?.() ?? !!getGlobalFlag('oneTheme');
 }
 
 export function useRuntimeVisualRefresh() {


### PR DESCRIPTION
*Issue #, if available: `aQokArCTx9ab`

*Description of changes:*

Recognize `.awsui-one-theme` as visual-refresh-compatible so vr components/layouts behave like vr when one-theme is active. Detection works via the `.awsui-one-theme` body class or global flag (`window[Symbol.for("awsui-global-flags")].oneTheme`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
