### PR TITLE
feat: resolve analytics label from associated <label for> element

### DIFF
--- a/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
+++ b/src/internal/analytics-metadata/__tests__/labels-utils.test.tsx
@@ -118,6 +118,26 @@ describe('getLabelFromElement', () => {
     const target2 = container.querySelector('#target2');
     expect(getLabelFromElement(target2 as HTMLElement)).toEqual('content');
   });
+  test('returns text of an associated <label for> when the element has no text of its own', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="target">Column name</label>
+        <input id="target" type="checkbox" />
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('Column name');
+  });
+  test('prefers aria-label over an associated <label for>', () => {
+    const { container } = render(
+      <div>
+        <label htmlFor="target">from label for</label>
+        <input id="target" type="checkbox" aria-label="from aria-label" />
+      </div>
+    );
+    const target = container.querySelector('#target');
+    expect(getLabelFromElement(target as HTMLElement)).toEqual('from aria-label');
+  });
 });
 
 describe('processLabel', () => {

--- a/src/internal/analytics-metadata/labels-utils.ts
+++ b/src/internal/analytics-metadata/labels-utils.ts
@@ -160,5 +160,14 @@ export const getLabelFromElement = (element: HTMLElement | null): string => {
     }
   }
 
+  const id = element.getAttribute('id');
+  if (id) {
+    const associatedLabel = element.ownerDocument.querySelector(`label[for="${CSS.escape(id)}"]`);
+    const associatedText = associatedLabel?.textContent?.trim();
+    if (associatedText) {
+      return associatedText;
+    }
+  }
+
   return element.textContent ? element.textContent.trim() : '';
 };


### PR DESCRIPTION
## Description

`getLabelFromElement` now resolves the text of an associated `label[for="id"]` when the element has no accessible name of its own. Resolution order becomes: `aria-label` → `aria-labelledby` → **`<label for>`** → `textContent`.

## Motivation

Autocapture analytics can't resolve a label for controls whose accessible name is bound only via an external `<label for>` (rather than an `aria-*` attribute or child text). AbstractSwitch already points its `detail.label` selector at the native `<input>` when used without a `label` prop — but that input has no aria/text of its own, so the label resolved to `''`. The most visible case is CollectionPreferences visible-content column toggles, which currently emit `select`/`deselect` events with an empty label.

## Testing

- Added unit tests: resolves via `<label for>`; `aria-label` still takes precedence.
- `npm run test:unit` (analytics-metadata), `npm run build`, `npm run lint` all pass.
