### PR TITLE
chore: Fixes scss utils exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,13 @@
       "require": "./internal/index.js",
       "default": "./mjs/internal/index.js"
     },
+    "./internal/focus-visible": {
+      "sass": "./internal/focus-visible/index.scss",
+      "style": "./internal/focus-visible/index.scss",
+      "require": "./internal/focus-visible/index.js",
+      "default": "./mjs/internal/focus-visible/index.js"
+    },
+    "./internal/style-api": "./internal/style-api/index.scss",
     "./internal/metrics": {
       "require": "./internal/metrics.js",
       "default": "./mjs/internal/metrics.js"


### PR DESCRIPTION
Without this, the utils exported from the toolkit cannot be used in environments that require explicit package exports, which includes webpack setup in component test pages, see: https://github.com/cloudscape-design/components/pull/4770

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
