### PR TITLE
feat: Add public analytics-metadata entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,14 @@
       "require": "./dom/index.js",
       "default": "./mjs/dom/index.js"
     },
+    "./analytics-metadata": {
+      "require": "./analytics-metadata/index.js",
+      "default": "./mjs/analytics-metadata/index.js"
+    },
+    "./analytics-metadata/utils": {
+      "require": "./analytics-metadata/utils.js",
+      "default": "./mjs/analytics-metadata/utils.js"
+    },
     "./internal": {
       "require": "./internal/index.js",
       "default": "./mjs/internal/index.js"
@@ -61,7 +69,9 @@
       "internal": ["./mjs/internal/index.d.ts"],
       "internal/*": ["./mjs/internal/*"],
       "dom": ["./mjs/dom/index.d.ts"],
-      "dom/*": ["./mjs/dom/*"]
+      "dom/*": ["./mjs/dom/*"],
+      "analytics-metadata": ["./mjs/analytics-metadata/index.d.ts"],
+      "analytics-metadata/*": ["./mjs/analytics-metadata/*"]
     }
   },
   "repository": {

--- a/src/analytics-metadata/__tests__/public-exports.test.ts
+++ b/src/analytics-metadata/__tests__/public-exports.test.ts
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as internalApi from '../../internal/analytics-metadata/index';
+import * as internalUtils from '../../internal/analytics-metadata/utils';
+import * as publicApi from '../index';
+import * as publicUtils from '../utils';
+
+const fragment = { component: { name: 'awsui.Test' } };
+
+afterEach(() => {
+  publicApi.activateAnalyticsMetadata(false);
+});
+
+describe('public analytics-metadata entry point', () => {
+  test('exposes the documented named exports', () => {
+    expect(Object.keys(publicApi).sort()).toEqual(['activateAnalyticsMetadata', 'getAnalyticsMetadataAttribute']);
+    expect(Object.keys(publicUtils).sort()).toEqual(['getComponentsTree', 'getGeneratedAnalyticsMetadata']);
+  });
+
+  test('re-exports the same function identities as the internal entry point', () => {
+    expect(publicApi.activateAnalyticsMetadata).toBe(internalApi.activateAnalyticsMetadata);
+    expect(publicApi.getAnalyticsMetadataAttribute).toBe(internalApi.getAnalyticsMetadataAttribute);
+    expect(publicUtils.getGeneratedAnalyticsMetadata).toBe(internalUtils.getGeneratedAnalyticsMetadata);
+    expect(publicUtils.getComponentsTree).toBe(internalUtils.getComponentsTree);
+  });
+
+  test('shares activation state with the internal entry point', () => {
+    publicApi.activateAnalyticsMetadata(true);
+    expect(internalApi.getAnalyticsMetadataAttribute(fragment)).toEqual({
+      'data-awsui-analytics': JSON.stringify(fragment),
+    });
+
+    publicApi.activateAnalyticsMetadata(false);
+    expect(internalApi.getAnalyticsMetadataAttribute(fragment)).toEqual({});
+  });
+});

--- a/src/analytics-metadata/index.ts
+++ b/src/analytics-metadata/index.ts
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { activateAnalyticsMetadata, getAnalyticsMetadataAttribute } from '../internal/analytics-metadata/index.js';
+export type {
+  GeneratedAnalyticsMetadata,
+  GeneratedAnalyticsMetadataFragment,
+  LabelIdentifier,
+} from '../internal/analytics-metadata/index.js';

--- a/src/analytics-metadata/utils.ts
+++ b/src/analytics-metadata/utils.ts
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+export { getComponentsTree, getGeneratedAnalyticsMetadata } from '../internal/analytics-metadata/utils.js';
+export type { GetComponentsTreeOptions, OptionItem, TabItem } from '../internal/analytics-metadata/utils.js';


### PR DESCRIPTION
## Summary

Adds a public `@cloudscape-design/component-toolkit/analytics-metadata` entry
point (and `.../analytics-metadata/utils`) exposing the analytics metadata API
that today is only reachable via `internal/analytics-metadata`.

Component libraries built on top of Cloudscape instrument their own components
with this mechanism, alongside the metadata Cloudscape components emit, so that
one extraction returns a single consistent hierarchy. Because the entry points
live under `internal/` with no stability commitment, such a library has to
redefine the types in a wrapper package to avoid leaking an internal path into
its own public API, and re-verify the surface on every toolkit release. With a
public path those redefinitions become plain re-exports.

The functions are already published in the package's `exports` map, so this is
closer to documenting existing surface than adding new API.

## Changes

- New `src/analytics-metadata/index.ts` re-exporting `activateAnalyticsMetadata`,
  `getAnalyticsMetadataAttribute` and the types `GeneratedAnalyticsMetadata`,
  `GeneratedAnalyticsMetadataFragment`, `LabelIdentifier`.
- New `src/analytics-metadata/utils.ts` re-exporting `getGeneratedAnalyticsMetadata`,
  `getComponentsTree` and the types `GetComponentsTreeOptions`, `OptionItem`, `TabItem`.
- `exports` and `typesVersions` entries for both paths.
- Unit test asserting the public surface, function identity with the internal
  entry point, and shared activation state.

Kept as two paths rather than one so component-runtime consumers of
`getAnalyticsMetadataAttribute` do not pull in the page-scanner and
label-extraction code.

## Non-goals

- No behaviour changes. Both files are pure re-exports.
- `internal/analytics-metadata` and `.../utils` are unchanged and not deprecated.
- No new implementation. The activation flag is module-level state, so a second
  copy would silently split it; re-exporting keeps one instance.
- No version bump or changelog (none exists in this repo).

## Testing

- `npm run build` — verified `lib/analytics-metadata/{index,utils}.{js,d.ts}` and
  `lib/mjs/analytics-metadata/{index,utils}.{js,d.ts}` are all emitted
- `npm run lint` — clean
- `CI=true npm run test:unit` — 52 suites / 491 tests pass
- Runtime resolution from `lib/`, both formats:
  `require('./analytics-metadata/index.js')` and
  `import('./mjs/analytics-metadata/utils.js')` export the expected names
- `git secrets --scan` on the changed files
- Integ tests not run locally (need Chrome + chromedriver); relying on CI

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.
