### PR TITLE
chore: Remediate 5 of 8 Dependabot security alerts (lockfile only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8538,9 +8538,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14831,9 +14831,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16239,9 +16239,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16704,9 +16704,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17420,13 +17420,21 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {
@@ -17548,6 +17556,16 @@
         "compress-commons": "^6.0.2",
         "readable-stream": "^4.0.0"
       },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 14"
       }


### PR DESCRIPTION
## Automated Dependabot security-alert remediation

Alert-driven remediation of this repository's **open** Dependabot security alerts.
Baseline: `9e19b1a32` on `main`.

### Alerts resolved (5 of 8)

| Alert | Sev | Package | Major line | Vulnerable range | First patched | Now resolved to | Advisory |
|---|---|---|---|---|---|---|---|
| #206 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) (CVE-2026-16728) |
| #207 | high | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272) (CVE-2026-13697) |
| #208 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) (CVE-2026-16729) |
| #209 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54) (CVE-2026-14643) |
| #210 | medium | `undici` | 7.x | `>= 7.0.0, < 7.29.0` | 7.29.0 | `7.29.0, 6.28.0` | [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5) (CVE-2026-15157) |

### :x: Alerts NOT resolved by this PR (3) — human decision required

| Alert | Sev | Package | Vulnerable range | First patched | Still installed | Advisory |
|---|---|---|---|---|---|---|
| #199 | medium | `react-router` | `>= 6.0.0, < 7.18.0` | 7.18.0 | `6.30.4` | [GHSA-wrjc-x8rr-h8h6](https://github.com/advisories/GHSA-wrjc-x8rr-h8h6) (CVE-2026-53669) |
| #198 | medium | `react-router-dom` | `>= 6.30.2, <= 6.30.4` | **none published** | `6.30.4` | [GHSA-jjmj-jmhj-qwj2](https://github.com/advisories/GHSA-jjmj-jmhj-qwj2) (CVE-2026-53668) |
| #197 | medium | `react-router` | `>= 6.4.0, < 7.18.0` | 7.18.0 | `6.30.4` | [GHSA-337j-9hxr-rhxg](https://github.com/advisories/GHSA-337j-9hxr-rhxg) (CVE-2026-53666) |

**Why these are not fixed here:**

* `react-router-dom` **has no patched version at all** on the 6.x line (advisory [GHSA-jjmj-jmhj-qwj2](https://github.com/advisories/GHSA-jjmj-jmhj-qwj2) lists `>= 6.30.2, <= 6.30.4` with *no* first-patched release). The only remediated package in that advisory is `react-router >= 7.13.0`.
* `react-router` is only patched at **`7.18.0`** — a **major** v6→v7 upgrade. It is installed here transitively via `react-router-dom@6.30.4`, so bumping `react-router` alone to 7.x would pair a v7 core with a v6 dom package and break at runtime. Pinning it via `overrides` would produce exactly that broken combination, so it was deliberately **not** attempted.
* A real fix therefore means **migrating off react-router-dom 6.x to react-router 7.x**, which is a framework migration, not a dependency bump. That is out of scope for automated remediation and needs an owner decision.

### How this was remediated

* **Rung 1 — `npm audit fix --package-lock-only --ignore-scripts`** (no `--force` was used anywhere in this run).
* The repo's own `prepare-package-lock` convention (`postinstall` in `@cloudscape-design/build-tools`) was applied afterwards, so no `@cloudscape-design/*` entries are (re-)introduced into the lockfile.
* npm's full reconciliation additionally healed unrelated pre-existing lockfile drift (stale entries, `dev`/`optional` flags, unrelated minor bumps). **That collateral was deliberately discarded**: only the security-relevant entries from npm's computed result were applied on top of the committed lockfile, so this diff contains alert-driven changes only.
* Verified with `npm ls --package-lock-only --all`: **zero new** unmet/invalid dependency problems versus `main`.

### Lockfile changes (6)

| Package | From | To | Scope | Lockfile path |
|---|---|---|---|---|
| `brace-expansion` | 2.1.3 | 2.1.4 | dev | `node_modules/glob/node_modules/brace-expansion` |
| `brace-expansion` | 2.1.3 | 2.1.4 | dev | `node_modules/readdir-glob/node_modules/brace-expansion` |
| `brace-expansion` | 5.0.8 | 5.0.9 | dev | `node_modules/test-exclude/node_modules/brace-expansion` |
| `undici` | 7.28.0 | 7.29.0 | dev | `node_modules/undici` |
| `yaml` | 2.3.1 | 2.9.0 | dev | `node_modules/yaml` |
| `yaml` | (new) | 2.3.1 | dev | `node_modules/lint-staged/node_modules/yaml` |

### NPMPM (NpmPrettyMuch) availability — internal build safety

**Not applicable — 0 non-dev dependencies changed.** Every version bump in this PR is `dev: true`, which the NPMPM availability check skips, so there is no internal-build (Brazil) impact and the check should come back green.

### Does merging clear this repository's alert list?

**No — partially.** Merging this PR is expected to close **5 of 8** open alerts. **3** will remain open: #199, #198, #197 (`react-router` / `react-router-dom`), which need the v6→v7 migration decision described above.

---

<sub>Existing Dependabot-authored PRs were deliberately **not** touched, reviewed, rebased, or closed by this run.</sub>

> Opened by roko-dependabot on behalf of @ernst-dev. Alert-driven remediation; not merged — a human must review and merge.
