### PR TITLE
feat: Add skipVisualRefresh option in initThemes

### DIFF
--- a/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
+++ b/src/internal/visual-mode/__tests__/use-runtime-visual-refresh.test.tsx
@@ -158,5 +158,31 @@ describe('useVisualRefresh', () => {
       initThemes();
       expect(console.warn).toHaveBeenCalledWith(expect.stringMatching(/Multiple theme flags are enabled/));
     });
+
+    test('skips visual-refresh class when skipVisualRefresh is true', () => {
+      window[awsuiVisualRefreshFlag] = () => true;
+      initThemes({ skipVisualRefresh: true });
+      expect(document.body).not.toHaveClass('awsui-visual-refresh');
+    });
+
+    test('adds one-theme class when skipVisualRefresh is true and oneTheme flag is set', () => {
+      (window as any)[awsuiGlobalFlagsSymbol] = { oneTheme: true };
+      initThemes({ skipVisualRefresh: true });
+      expect(document.body).toHaveClass('awsui-one-theme');
+    });
+
+    test('adds one-theme class and skips visual-refresh when both flags set and skipVisualRefresh is true', () => {
+      window[awsuiVisualRefreshFlag] = () => true;
+      (window as any)[awsuiGlobalFlagsSymbol] = { oneTheme: true };
+      initThemes({ skipVisualRefresh: true });
+      expect(document.body).toHaveClass('awsui-one-theme');
+      expect(document.body).not.toHaveClass('awsui-visual-refresh');
+    });
+
+    test('does not skip visual-refresh class when skipVisualRefresh is false', () => {
+      window[awsuiVisualRefreshFlag] = () => true;
+      initThemes({ skipVisualRefresh: false });
+      expect(document.body).toHaveClass('awsui-visual-refresh');
+    });
   });
 });

--- a/src/internal/visual-mode/index.ts
+++ b/src/internal/visual-mode/index.ts
@@ -132,8 +132,22 @@ function applyThemeClassName(theme: Theme) {
   }
 }
 
-export function initThemes() {
-  const flaggedThemes = themePrecedence.filter(theme => themeDefinitions[theme].isFlagActive());
+export interface InitThemesOptions {
+  /**
+   * When true, skip applying the visual-refresh body class.
+   * Use this for packages where visual refresh styles are always active (ALWAYS_VISUAL_REFRESH mode),
+   * so the body class is unnecessary — only one-theme class will be applied.
+   */
+  skipVisualRefresh?: boolean;
+}
+
+export function initThemes(options?: InitThemesOptions) {
+  const flaggedThemes = themePrecedence.filter(theme => {
+    if (options?.skipVisualRefresh && theme === Theme.VisualRefresh) {
+      return false;
+    }
+    return themeDefinitions[theme].isFlagActive();
+  });
   if (isDevelopment && flaggedThemes.length > 1) {
     warnOnce(
       'Theme',


### PR DESCRIPTION
### Description of changes:
  
Add `skipVisualRefresh` option to `initThemes()` to support one-theme in the vr-only artifact.
  
### Problem
  
  The vr-only artifact (setting ALWAYS_VISUAL_REFRESH=true) short-circuits `useVisualRefresh to () => true`, so useRuntimeVisualRefresh and initThemes() never run. This means the `awsui-one-theme` body class is never applied even when the global flag is set.
  
### Solution
  
 `initThemes()` now accepts an optional `{ skipVisualRefresh?: boolean }` parameter. When true, it skips adding `awsui-visual-refresh`  but still applies other theme.
  
The components package will call initThemes({ skipVisualRefresh: ALWAYS_VISUAL_REFRESH }) from useBaseComponent to ensure theme classes are applied regardless of the ALWAYS_VISUAL_REFRESH flag. See this PR https://github.com/cloudscape-design/components/pull/4894


### Test
Add unit test and will add integration test internally.